### PR TITLE
Make properties protected instead of private

### DIFF
--- a/Entity/AbstractRefreshToken.php
+++ b/Entity/AbstractRefreshToken.php
@@ -24,21 +24,21 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
      *
      * @Assert\NotBlank()
      */
-    private $refreshToken;
+    protected $refreshToken;
 
     /**
      * @var string
      *
      * @Assert\NotBlank()
      */
-    private $username;
+    protected $username;
 
     /**
      * @var \DateTime
      *
      * @Assert\NotBlank()
      */
-    private $valid;
+    protected $valid;
 
     /**
      * {@inheritdoc}

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -31,12 +31,12 @@ class RefreshToken
     /**
      * @var RefreshTokenAuthenticator
      */
-    private $authenticator;
+    protected $authenticator;
 
     /**
      * @var RefreshTokenProvider
      */
-    private $provider;
+    protected $provider;
 
     /**
      * @var AuthenticationSuccessHandlerInterface
@@ -46,32 +46,32 @@ class RefreshToken
     /**
      * @var AuthenticationFailureHandlerInterface
      */
-    private $failureHandler;
+    protected $failureHandler;
 
     /**
      * @var RefreshTokenManagerInterface
      */
-    private $refreshTokenManager;
+    protected $refreshTokenManager;
 
     /**
      * @var int
      */
-    private $ttl;
+    protected $ttl;
 
     /**
      * @var string
      */
-    private $providerKey;
+    protected $providerKey;
 
     /**
      * @var bool
      */
-    private $ttlUpdate;
+    protected $ttlUpdate;
 
     /**
      * @var EventDispatcherInterface
      */
-    private $eventDispatcher;
+    protected $eventDispatcher;
 
     /**
      * RefreshToken constructor.


### PR DESCRIPTION
I have a somewhat unique Symfony set up with multiple entity managers. I need to be able to extend some classes, which means making the properties protected would be a big help.