### PR TITLE
Add conflict with "doctrine/mongodb-odm:>=2.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
     "doctrine/orm": "^2.4.8",
     "phpspec/phpspec": "^3.0|^4.0"
   },
+  "conflict": {
+    "doctrine/mongodb-odm": ">=2.0"
+  },
   "config": {
     "bin-dir": "bin"
   },


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

Class `Doctrine\ODM\MongoDB\DocumentRepository` was removed since [`doctrine/mongodb-odm:2.0.0-alpha1`](
https://github.com/doctrine/mongodb-odm/compare/1.3.0-RC1...2.0.0-alpha1#diff-9e3735275d8a42dad48be6be39159d05L40); so we must disallow these versions in order to avoid issues like #162 is trying to solve.

Closes #162.