### PR TITLE
ODM 2.0 compatibility: trigger autoload on detecting doctrine/mongodb-odm version

### DIFF
--- a/Document/RefreshTokenRepository.php
+++ b/Document/RefreshTokenRepository.php
@@ -6,7 +6,7 @@ use Doctrine\ODM\MongoDB\DocumentRepository;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository as MongoDBDocumentRepository;
 use Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken;
 
-if (class_exists(MongoDBDocumentRepository::class, false)) {
+if (class_exists(MongoDBDocumentRepository::class)) {
     // Support for doctrine/mongodb-odm >= 2.0
     class BaseRepository extends MongoDBDocumentRepository
     {


### PR DESCRIPTION
# Abstract 
This allows the auload to be triggered, when checking for the presence of a `doctrine/mongodb-odm >= 2.0` repository class.

This is needed as during `bin/console cache:warmup`, the check would fail even if the checked class is indeed present, at the class was not autoloaded.

# Bug
Example on a fresh install of API Platform `2.5` &  ̀dev-master` of markitosgv/JWTRefreshTokenBundle

```
/var/www/html $ bin/console cache:warmup

Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "DocumentRepository" from namespace "Doctrine\ODM\MongoDB".
Did you forget a "use" statement for "Doctrine\ODM\MongoDB\Repository\DocumentRepository"? in /var/www/html/vendor/gesdinet/jwt-refresh-token-bundle/Document/RefreshTokenRepository.php:16
Stack trace:
#0 /var/www/html/vendor/api-platform/core/src/Util/ReflectionClassRecursiveIterator.php(48): require_once()
#1 /var/www/html/vendor/api-platform/core/src/Bridge/Symfony/Bundle/DependencyInjection/Compiler/AnnotationFilterPass.php(50): ApiPlatform\Core\Util\ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories(Array)
#2 /var/www/html/vendor/symfony/dependency-injection/Compiler/Compiler.php(94): ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\Compiler\AnnotationFilterPass->process(Object(Symfony\Component\DependencyInjection\ContainerBuilder))
#3 /var/www/html/vendor/symfony/dependency-injection/ContainerBuilder.php(754): Symfony\Componen in /var/www/html/vendor/gesdinet/jwt-refresh-token-bundle/Document/RefreshTokenRepository.php on line 16
``` 

This error is fixed with this PR, as the `class_exists` will now trigger the autoload :)