### PR TITLE
Missing annotation @ORM\Entity()

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ use Gesdinet\JWTRefreshTokenBundle\Entity\AbstractRefreshToken;
 /**
  * This class override Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken to have another table name.
  *
+ * @ORM\Entity()
  * @ORM\Table("jwt_refresh_token")
  */
 class JwtRefreshToken extends AbstractRefreshToken


### PR DESCRIPTION
Without this annotation class is not used and fallback to default one even with refresh_token_class in config.
Hope this helps