### PR TITLE
Created service from RequestRefreshToken to allow override default behavior

### DIFF
--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -43,6 +43,11 @@ class AttachRefreshTokenOnSuccessListener
     protected $requestStack;
 
     /**
+     * @var RequestRefreshToken
+     */
+    protected $requestRefreshToken;
+
+    /**
      * @var string
      */
     protected $userIdentityField;
@@ -64,6 +69,7 @@ class AttachRefreshTokenOnSuccessListener
      * @param int                          $ttl
      * @param ValidatorInterface           $validator
      * @param RequestStack                 $requestStack
+     * @param RequestRefreshToken          $requestRefreshToken
      * @param string                       $userIdentityField
      * @param string                       $tokenParameterName
      * @param bool                         $singleUse
@@ -73,6 +79,7 @@ class AttachRefreshTokenOnSuccessListener
         $ttl,
         ValidatorInterface $validator,
         RequestStack $requestStack,
+        RequestRefreshToken $requestRefreshToken,
         $userIdentityField,
         $tokenParameterName,
         $singleUse
@@ -81,6 +88,7 @@ class AttachRefreshTokenOnSuccessListener
         $this->ttl = $ttl;
         $this->validator = $validator;
         $this->requestStack = $requestStack;
+        $this->requestRefreshToken = $requestRefreshToken;
         $this->userIdentityField = $userIdentityField;
         $this->tokenParameterName = $tokenParameterName;
         $this->singleUse = $singleUse;
@@ -90,13 +98,17 @@ class AttachRefreshTokenOnSuccessListener
     {
         $data = $event->getData();
         $user = $event->getUser();
-        $request = $this->requestStack->getCurrentRequest();
 
         if (!$user instanceof UserInterface) {
             return;
         }
 
-        $refreshTokenString = RequestRefreshToken::getRefreshToken($request, $this->tokenParameterName);
+        $refreshTokenString = null;
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request) {
+            $refreshTokenString = $this->requestRefreshToken->getRefreshToken($request, $this->tokenParameterName);
+        }
 
         if ($refreshTokenString && true === $this->singleUse) {
             $refreshToken = $this->refreshTokenManager->get($refreshTokenString);

--- a/Request/RequestRefreshToken.php
+++ b/Request/RequestRefreshToken.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestRefreshToken
 {
-    public static function getRefreshToken(Request $request, $tokenParameterName)
+    public function getRefreshToken(Request $request, $tokenParameterName)
     {
         $refreshTokenString = null;
         if (false !== strpos($request->getContentType(), 'json')) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,9 @@ services:
 
     Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface: '@gesdinet.jwtrefreshtoken.refresh_token_manager'
 
+    gesdinet.jwtrefreshtoken.request_refreshtoken:
+        class: Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken
+
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
         public: true

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "@gesdinet.jwtrefreshtoken.request_refreshtoken", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 

--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -34,6 +34,11 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
     private $userChecker;
 
     /**
+     * @var RequestRefreshToken
+     */
+    protected $requestRefreshToken;
+
+    /**
      * @var string
      */
     protected $tokenParameterName;
@@ -42,23 +47,28 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
      * Constructor.
      *
      * @param UserCheckerInterface $userChecker
+     * @param RequestRefreshToken  $requestRefreshToken
      * @param string               $tokenParameterName
      */
-    public function __construct(UserCheckerInterface $userChecker, $tokenParameterName)
-    {
+    public function __construct(
+        UserCheckerInterface $userChecker,
+        RequestRefreshToken $requestRefreshToken,
+        $tokenParameterName
+    ) {
         $this->userChecker = $userChecker;
+        $this->requestRefreshToken = $requestRefreshToken;
         $this->tokenParameterName = $tokenParameterName;
     }
 
     public function supports(Request $request)
     {
-        return null !== RequestRefreshToken::getRefreshToken($request, $this->tokenParameterName);
+        return null !== $this->requestRefreshToken->getRefreshToken($request, $this->tokenParameterName);
     }
 
     public function getCredentials(Request $request)
     {
         return [
-            'token' => RequestRefreshToken::getRefreshToken($request, $this->tokenParameterName),
+            'token' => $this->requestRefreshToken->getRefreshToken($request, $this->tokenParameterName),
         ];
     }
 

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Gesdinet\JWTRefreshTokenBundle\EventListener;
 
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -19,12 +20,16 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 {
     const TOKEN_PARAMETER_NAME = 'refresh_token';
 
-    public function let(RefreshTokenManagerInterface $refreshTokenManager, ValidatorInterface $validator, RequestStack $requestStack)
-    {
+    public function let(
+        RefreshTokenManagerInterface $refreshTokenManager,
+        ValidatorInterface $validator,
+        RequestStack $requestStack,
+        RequestRefreshToken $requestRefreshToken
+    ) {
         $ttl = 2592000;
         $userIdentityField = 'username';
         $singleUse = false;
-        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $userIdentityField, self::TOKEN_PARAMETER_NAME, $singleUse);
+        $this->beConstructedWith($refreshTokenManager, $ttl, $validator, $requestStack, $requestRefreshToken, $userIdentityField, self::TOKEN_PARAMETER_NAME, $singleUse);
     }
 
     public function it_is_initializable()
@@ -32,7 +37,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $this->shouldHaveType('Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener');
     }
 
-    public function it_attach_token_on_refresh(AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, RequestStack $requestStack)
+    public function it_attach_token_on_refresh(AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, RequestStack $requestStack, RequestRefreshToken $requestRefreshToken)
     {
         $event->getData()->willReturn(array());
         $event->getUser()->willReturn($user);
@@ -44,6 +49,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
         $request->request = new ParameterBag($refreshTokenArray);
 
         $requestStack->getCurrentRequest()->willReturn($request);
+        $requestRefreshToken->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->willReturn('thepreviouslyissuedrefreshtoken');
 
         $event->setData(Argument::exact($refreshTokenArray))->shouldBeCalled();
 

--- a/spec/Request/RequestRefreshTokenSpec.php
+++ b/spec/Request/RequestRefreshTokenSpec.php
@@ -14,7 +14,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::createFromGlobals();
         $request->attributes->set(self::TOKEN_PARAMETER_NAME, 'abcd');
 
-        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
+        $this->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_body()
@@ -22,7 +22,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::createFromGlobals();
         $request->request->set(self::TOKEN_PARAMETER_NAME, 'abcd');
 
-        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
+        $this->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json()
@@ -30,7 +30,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create('', 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/json');
 
-        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
+        $this->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_x()
@@ -38,7 +38,7 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create('', 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/x-json');
 
-        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
+        $this->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 
     public function it_gets_from_json_parameter()
@@ -46,6 +46,6 @@ class RequestRefreshTokenSpec extends ObjectBehavior
         $request = Request::create('', 'POST', array(), array(), array(), array(), json_encode(array(self::TOKEN_PARAMETER_NAME => 'abcd')));
         $request->headers->set('content_type', 'application/json;charset=UTF-8');
 
-        $this::getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
+        $this->getRefreshToken($request, self::TOKEN_PARAMETER_NAME)->shouldBe('abcd');
     }
 }

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\Security\Authenticator;
 
+use Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -9,10 +10,10 @@ use Symfony\Component\Security\Core\User\UserCheckerInterface;
 
 class RefreshTokenAuthenticatorSpec extends ObjectBehavior
 {
-    public function let(UserCheckerInterface $userChecker)
+    public function let(UserCheckerInterface $userChecker, RequestRefreshToken $requestRefreshToken)
     {
         $tokenParameterName = 'refresh_token';
-        $this->beConstructedWith($userChecker, $tokenParameterName);
+        $this->beConstructedWith($userChecker, $requestRefreshToken, $tokenParameterName);
     }
 
     public function it_is_initializable()


### PR DESCRIPTION
Hi, @markitosgv!

This PR creates  a service from the `RequestRefreshToken` class. It will allow changing the refresh token extraction mode (cookie headers, etc.) without being restricted to a specific `Content-Type` header, and without the need to overload the `AttachRefreshTokenOnSuccessListener`.