### PR TITLE
Fix ObjectManager namespace for doctrine 2.7

### DIFF
--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -11,7 +11,7 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager as BaseRefreshTokenManager;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;


### PR DESCRIPTION
the objectManager not exist for the last update to Doctirne