### PR TITLE
Support for doctrine/common v3

### DIFF
--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -11,7 +11,7 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager as BaseRefreshTokenManager;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ Installation
 With Doctrine's ORM
 
 ```bash
-$ composer require "doctrine/orm" "doctrine/doctrine-bundle" "gesdinet/jwt-refresh-token-bundle"
+$ composer require "doctrine/orm" "doctrine/doctrine-bundle" "ricardodevries/jwt-refresh-token-bundle"
 ```
 
 With Doctrine's MongoDB ODM
 
 ```bash
-$ composer require "doctrine/mongodb-odm-bundle" "gesdinet/jwt-refresh-token-bundle"
+$ composer require "doctrine/mongodb-odm-bundle" "ricardodevries/jwt-refresh-token-bundle"
 ```
 
 or edit composer.json:
 
     // ...
-    "gesdinet/jwt-refresh-token-bundle": "~0.1",
+    "ricardodevries/jwt-refresh-token-bundle": "~0.1",
     "doctrine/orm": "^2.4.8",
     "doctrine/doctrine-bundle": "~1.4",
     "doctrine/mongodb-odm-bundle": "^3.4"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name" : "gesdinet/jwt-refresh-token-bundle",
+  "name" : "ricardodevries/jwt-refresh-token-bundle",
   "description" : "Implements a refresh token system over Json Web Tokens in Symfony",
   "type" : "symfony-bundle",
   "authors" : [{

--- a/spec/Doctrine/RefreshTokenManagerSpec.php
+++ b/spec/Doctrine/RefreshTokenManagerSpec.php
@@ -2,8 +2,8 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use PhpSpec\ObjectBehavior;


### PR DESCRIPTION
As reported in https://github.com/markitosgv/JWTRefreshTokenBundle/issues/200 by @HeiJon this pull request adds support for doctrine/common v3. It already had open submitted pull requests where this pull request is based on: https://github.com/markitosgv/JWTRefreshTokenBundle/pull/204 by @Invis1bleReborn, https://github.com/markitosgv/JWTRefreshTokenBundle/pull/206 by @mnowaczyk and https://github.com/markitosgv/JWTRefreshTokenBundle/pull/207 by @AnisGloulou.