### PR TITLE
Extract token creation

### DIFF
--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -55,13 +55,9 @@ class AttachRefreshTokenOnSuccessListener
     /**
      * AttachRefreshTokenOnSuccessListener constructor.
      *
-     * @param RefreshTokenManagerInterface $refreshTokenManager
-     * @param RefreshTokenServiceInterface $refreshTokenService
-     * @param ValidatorInterface $validator
-     * @param RequestStack $requestStack
      * @param string $userIdentityField
      * @param string $tokenParameterName
-     * @param bool $singleUse
+     * @param bool   $singleUse
      */
     public function __construct(
         RefreshTokenManagerInterface $refreshTokenManager,

--- a/README.md
+++ b/README.md
@@ -372,6 +372,33 @@ curl -X POST -d refresh_token="xxxx4b54b0076d2fcc5a51a6e60c0fb83b0bc90b47e2c886a
 
 This call returns a new valid JWT token renewing valid datetime of your refresh token.
 
+### Creating Refresh tokens programmatically
+
+It might be useful in many cases to manually create a refresh token for a given user. To achieve this, use the `gesdinet.jwtrefreshtoken` service directly.
+
+For example:
+
+```php
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Gesdinet\JWTRefreshTokenBundle\Service\RefreshTokenInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class ApiController extends Controller
+{
+    public function getRefreshToken(UserInterface $user, RefreshTokenInterface $refreshTokenService)
+    {
+        $refreshToken = $refreshTokenService->create($user);
+
+        return new JsonResponse(['token' => $refreshToken->getRefreshToken()]);
+    }
+}
+```
+
 Useful Commands
 ---------------
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,7 +15,18 @@ services:
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
         public: true
-        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%", "@event_dispatcher", "%gesdinet_jwt_refresh_token.user_identity_field%", "@validator" ]
+        arguments:
+            - "@gesdinet.jwtrefreshtoken.authenticator"
+            - "@gesdinet.jwtrefreshtoken.user_provider"
+            - "@lexik_jwt_authentication.handler.authentication_success"
+            - "@lexik_jwt_authentication.handler.authentication_failure"
+            - "@gesdinet.jwtrefreshtoken.refresh_token_manager"
+            - "%gesdinet_jwt_refresh_token.ttl%"
+            - "%gesdinet_jwt_refresh_token.security.firewall%"
+            - "%gesdinet_jwt_refresh_token.ttl_update%"
+            - "%gesdinet_jwt_refresh_token.user_identity_field%"
+            - "@event_dispatcher"
+            - "@validator"
 
     Gesdinet\JWTRefreshTokenBundle\Service\RefreshTokenInterface: '@gesdinet.jwtrefreshtoken'
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     gesdinet.jwtrefreshtoken.send_token:
         class: Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener
-        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.user_identity_field%", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.refresh_token_manager", "@gesdinet.jwtrefreshtoken", "@validator", "@request_stack", "%gesdinet_jwt_refresh_token.token_parameter_name%", "%gesdinet_jwt_refresh_token.single_use%" ]
         tags:
             - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: attachRefreshToken }
 
@@ -15,7 +15,9 @@ services:
     gesdinet.jwtrefreshtoken:
         class: Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken
         public: true
-        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%", "@event_dispatcher" ]
+        arguments: [ "@gesdinet.jwtrefreshtoken.authenticator", "@gesdinet.jwtrefreshtoken.user_provider", "@lexik_jwt_authentication.handler.authentication_success", "@lexik_jwt_authentication.handler.authentication_failure", "@gesdinet.jwtrefreshtoken.refresh_token_manager", "%gesdinet_jwt_refresh_token.ttl%", "%gesdinet_jwt_refresh_token.security.firewall%", "%gesdinet_jwt_refresh_token.ttl_update%", "@event_dispatcher", "%gesdinet_jwt_refresh_token.user_identity_field%", "@validator" ]
+
+    Gesdinet\JWTRefreshTokenBundle\Service\RefreshTokenInterface: '@gesdinet.jwtrefreshtoken'
 
     gesdinet.jwtrefreshtoken.user_provider:
         class: Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -90,10 +90,10 @@ class RefreshToken implements RefreshTokenInterface
     /**
      * RefreshToken constructor.
      *
-     * @param int       $ttl
-     * @param string    $providerKey
-     * @param bool      $ttlUpdate
-     * @param string    $userIdentityField
+     * @param int    $ttl
+     * @param string $providerKey
+     * @param bool   $ttlUpdate
+     * @param string $userIdentityField
      */
     public function __construct(
         RefreshTokenAuthenticator $authenticator,
@@ -179,7 +179,7 @@ class RefreshToken implements RefreshTokenInterface
     public function create(UserInterface $user)
     {
         $datetime = new \DateTime();
-        $datetime->modify('+'.$this->ttl.' seconds');
+        $datetime->modify('+' . $this->ttl . ' seconds');
 
         $refreshToken = $this->refreshTokenManager->create();
 

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -90,17 +90,10 @@ class RefreshToken implements RefreshTokenInterface
     /**
      * RefreshToken constructor.
      *
-     * @param RefreshTokenAuthenticator $authenticator
-     * @param RefreshTokenProvider $provider
-     * @param AuthenticationSuccessHandlerInterface $successHandler
-     * @param AuthenticationFailureHandlerInterface $failureHandler
-     * @param RefreshTokenManagerInterface          $refreshTokenManager
-     * @param int                                   $ttl
-     * @param string                                $providerKey
-     * @param bool                                  $ttlUpdate
-     * @param string                                $userIdentityField
-     * @param EventDispatcherInterface              $eventDispatcher
-     * @param ValidatorInterface                    $validator
+     * @param int       $ttl
+     * @param string    $providerKey
+     * @param bool      $ttlUpdate
+     * @param string    $userIdentityField
      */
     public function __construct(
         RefreshTokenAuthenticator $authenticator,
@@ -130,8 +123,6 @@ class RefreshToken implements RefreshTokenInterface
 
     /**
      * Refresh token.
-     *
-     * @param Request $request
      *
      * @return mixed
      *
@@ -181,9 +172,7 @@ class RefreshToken implements RefreshTokenInterface
     }
 
     /**
-     * Refresh token.
-     *
-     * @param UserInterface $user
+     * Creates a token.
      *
      * @return ModelRefreshTokenInterface The refresh token
      */

--- a/Service/RefreshTokenInterface.php
+++ b/Service/RefreshTokenInterface.php
@@ -11,16 +11,12 @@ interface RefreshTokenInterface
     /**
      * Refresh token.
      *
-     * @param Request $request
-     *
      * @return mixed
      */
     public function refresh(Request $request);
 
     /**
      * Creates a token.
-     *
-     * @param UserInterface $user
      *
      * @return ModelRefreshTokenInterface The refresh token
      */

--- a/Service/RefreshTokenInterface.php
+++ b/Service/RefreshTokenInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\Service;
+
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface as ModelRefreshTokenInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface RefreshTokenInterface
+{
+    /**
+     * Refresh token.
+     *
+     * @param Request $request
+     *
+     * @return mixed
+     */
+    public function refresh(Request $request);
+
+    /**
+     * Creates a token.
+     *
+     * @param UserInterface $user
+     *
+     * @return ModelRefreshTokenInterface The refresh token
+     */
+    public function create(UserInterface $user);
+}

--- a/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
+++ b/spec/EventListener/AttachRefreshTokenOnSuccessListenerSpec.php
@@ -37,11 +37,11 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 
     public function it_attach_token_on_refresh(AuthenticationSuccessEvent $event, UserInterface $user, RefreshToken $refreshToken, $refreshTokenManager, RequestStack $requestStack)
     {
-        $event->getData()->willReturn(array());
+        $event->getData()->willReturn([]);
         $event->getUser()->willReturn($user);
 
-        $refreshTokenArray = array(self::TOKEN_PARAMETER_NAME => 'thepreviouslyissuedrefreshtoken');
-        $headers = new HeaderBag(array('content_type' => 'not-json'));
+        $refreshTokenArray = [self::TOKEN_PARAMETER_NAME => 'thepreviouslyissuedrefreshtoken'];
+        $headers = new HeaderBag(['content_type' => 'not-json']);
         $request = new Request();
         $request->headers = $headers;
         $request->request = new ParameterBag($refreshTokenArray);
@@ -57,10 +57,10 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
     {
         $this->beConstructedWith($refreshTokenManager, $refreshTokenService, $validator, $requestStack, self::TOKEN_PARAMETER_NAME, false);
 
-        $event->getData()->willReturn(array());
+        $event->getData()->willReturn([]);
         $event->getUser()->willReturn($user);
 
-        $headers = new HeaderBag(array('content_type' => 'not-json'));
+        $headers = new HeaderBag(['content_type' => 'not-json']);
         $request = new Request();
         $request->headers = $headers;
         $request->request = new ParameterBag();
@@ -69,7 +69,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 
         $refreshTokenService->create(Argument::any())->willReturn($refreshToken);
 
-        $violationList = new ConstraintViolationList(array());
+        $violationList = new ConstraintViolationList([]);
         $validator->validate($refreshToken)->willReturn($violationList);
 
         $refreshTokenManager->save($refreshToken)->shouldBeCalled();
@@ -81,7 +81,7 @@ class AttachRefreshTokenOnSuccessListenerSpec extends ObjectBehavior
 
     public function it_is_not_valid_user(AuthenticationSuccessEvent $event)
     {
-        $event->getData()->willReturn(array());
+        $event->getData()->willReturn([]);
         $event->getUser()->willReturn(null);
 
         $this->attachRefreshToken($event);

--- a/spec/Service/RefreshTokenSpec.php
+++ b/spec/Service/RefreshTokenSpec.php
@@ -13,19 +13,23 @@ use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class RefreshTokenSpec extends ObjectBehavior
 {
-    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, EventDispatcherInterface $eventDispatcher)
+    public function let(RefreshTokenAuthenticator $authenticator, RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, RefreshTokenManagerInterface $refreshTokenManager, EventDispatcherInterface $eventDispatcher, ValidatorInterface $validator)
     {
         $ttl = 2592000;
         $ttlUpdate = false;
         $providerKey = 'testkey';
+        $userIdentityField = 'Username';
 
         $eventDispatcher->dispatch(Argument::any(), Argument::any())->willReturn(Argument::any());
 
-        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, $ttl, $providerKey, $ttlUpdate, $eventDispatcher);
+        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, $ttl, $providerKey, $ttlUpdate, $userIdentityField, $eventDispatcher, $validator);
     }
 
     public function it_is_initializable()
@@ -44,9 +48,9 @@ class RefreshTokenSpec extends ObjectBehavior
         $this->refresh($request);
     }
 
-    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, EventDispatcherInterface $eventDispatcher)
+    public function it_refresh_token_with_ttl_update(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, EventDispatcherInterface $eventDispatcher, ValidatorInterface $validator)
     {
-        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true, $eventDispatcher);
+        $this->beConstructedWith($authenticator, $provider, $successHandler, $failureHandler, $refreshTokenManager, 2592000, 'testkey', true, '', $eventDispatcher, $validator);
 
         $authenticator->getCredentials(Argument::any())->willReturn(['token' => '1234']);
         $authenticator->getUser(Argument::any(), Argument::any())->willReturn(new User('test', 'test'));
@@ -70,5 +74,19 @@ class RefreshTokenSpec extends ObjectBehavior
         $failureHandler->onAuthenticationFailure(Argument::any(), Argument::any())->shouldBeCalled();
 
         $this->refresh($request);
+    }
+
+    public function it_creates_a_refresh_token(RefreshTokenProvider $provider, AuthenticationSuccessHandler $successHandler, AuthenticationFailureHandler $failureHandler, Request $request, RefreshTokenManagerInterface $refreshTokenManager, $authenticator, $token, PostAuthenticationGuardToken $postAuthenticationGuardToken, RefreshTokenInterface $refreshToken, EventDispatcherInterface $eventDispatcher, ValidatorInterface $validator, UserInterface $user, ConstraintViolationListInterface $errors)
+    {
+        $user->getUsername()->willReturn('testuser');
+
+        $refreshTokenManager->create()->willReturn($refreshToken);
+        $refreshToken->setUsername('testuser')->shouldBeCalled();
+        $refreshToken->setRefreshToken()->shouldBeCalled();
+        $refreshToken->setValid(Argument::type(\DateTime::class))->shouldBeCalled();
+        $validator->validate($refreshToken)->willReturn($errors);
+        $refreshTokenManager->save($refreshToken)->shouldBeCalled();
+
+        $this->create($user);
     }
 }


### PR DESCRIPTION
Similar to https://github.com/markitosgv/JWTRefreshTokenBundle/pull/190 this pull request extracts the token generation into the RefreshToken Service and makes it acceptable via a new Interface. This might be useful because it allows users of this library to programmatically create refresh tokens. This might be useful for applications that are not web based (native apps etc). 