### PR TITLE
Add exception if user does not exists

### DIFF
--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -77,6 +77,10 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
 
         $user = $userProvider->loadUserByUsername($username);
 
+        if (null === $user) {
+            throw new AuthenticationException(sprintf('User with refresh token "%s" does not exist.', $refreshToken));
+        }
+
         $this->userChecker->checkPreAuth($user);
         $this->userChecker->checkPostAuth($user);
 


### PR DESCRIPTION
@markitosgv. Can you kindly merge this small change please. My user provider returns a null object as well in specific scenario. 