### PR TITLE
Clarify that `RefreshTokenManagerInterface::get()` can also return null

### DIFF
--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -50,7 +50,7 @@ class RefreshTokenManager extends BaseRefreshTokenManager
     /**
      * @param string $refreshToken
      *
-     * @return RefreshTokenInterface
+     * @return RefreshTokenInterface|null
      */
     public function get($refreshToken)
     {

--- a/Model/RefreshTokenManagerInterface.php
+++ b/Model/RefreshTokenManagerInterface.php
@@ -29,7 +29,7 @@ interface RefreshTokenManagerInterface
     /**
      * @param string $refreshToken
      *
-     * @return RefreshTokenInterface
+     * @return RefreshTokenInterface|null
      */
     public function get($refreshToken);
 


### PR DESCRIPTION
The current implementation of the refresh token manager supports null returns by way of Doctrine's `ObjectRepository` having a null return on `findOneBy()`.  The null return is also [explicitly checked](https://github.com/markitosgv/JWTRefreshTokenBundle/blob/a0eb70dcbf53fe1c63ca27335a19eec19318a484/Service/RefreshToken.php#L129) in the refresh service.  So, this pull request updates the interface to clarify that the return from `RefreshTokenManagerInterface::get()` is nullable.