### PR TITLE
The default config values were being used in spite of specific values…

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('gesdinet_jwt_refresh_token');
 
         $rootNode
+            ->addDefaultsIfNotSet()
             ->children()
                 ->integerNode('ttl')->defaultValue(2592000)->end()
                 ->booleanNode('ttl_update')->defaultFalse()->end()


### PR DESCRIPTION
… being set. Told the node that defaults should only be set if the node has no value.

This should fix [https://github.com/markitosgv/JWTRefreshTokenBundle/issues/234](Issue 234). Single use works but in 0.11.1 it is impossible to enable it. It is also impossible to set some of the other config parameters.