### PR TITLE
CI updates and bump minimum supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,77 @@
 language: php
 
-sudo: false
+dist: xenial
 
 services:
   - mongodb
 
+env:
+  global:
+    - COMPOSER_FLAGS="--prefer-dist --no-interaction"
+
 matrix:
   fast_finish: true
   include:
-      # 3.4.*
+    # Build ensuring minimum dependencies are valid
     - php: 7.1
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.2
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.3
-      env: SYMFONY_VERSION=3.4.*
-      # 4.3.*
+      env: SYMFONY_REQUIRE=3.4.* COMPOSER_FLAGS="--prefer-lowest --prefer-dist --no-interaction"
+
+    # 3.4.*
     - php: 7.1
-      env: SYMFONY_VERSION=4.3.*
+      env: SYMFONY_REQUIRE=3.4.*
     - php: 7.2
-      env: SYMFONY_VERSION=4.3.*
+      env: SYMFONY_REQUIRE=3.4.*
     - php: 7.3
-      env: SYMFONY_VERSION=4.3.*
-      # 4.4.*
+      env: SYMFONY_REQUIRE=3.4.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=3.4.*
+
+    # 4.4.*
     - php: 7.1
-      env: SYMFONY_VERSION=4.4.*
+      env: SYMFONY_REQUIRE=4.4.*
     - php: 7.2
-      env: SYMFONY_VERSION=4.4.*
+      env: SYMFONY_REQUIRE=4.4.*
     - php: 7.3
-      env: SYMFONY_VERSION=4.4.*
-      # 5.0.*
+      env: SYMFONY_REQUIRE=4.4.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=4.4.*
+    - php: 8.0
+      env: SYMFONY_REQUIRE=4.4.*
+
+    # 5.2.*
     - php: 7.2
-      env: SYMFONY_VERSION=5.0.*
+      env: SYMFONY_REQUIRE=5.2.*
     - php: 7.3
-      env: SYMFONY_VERSION=5.0.*
+      env: SYMFONY_REQUIRE=5.2.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=5.2.*
+    - php: 8.0
+      env: SYMFONY_REQUIRE=5.2.*
+
+    # 5.3.*
+    - php: 7.2
+      env: SYMFONY_REQUIRE=5.3.*
+    - php: 7.3
+      env: SYMFONY_REQUIRE=5.3.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=5.3.*
+    - php: 8.0
+      env: SYMFONY_REQUIRE=5.3.*
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
+  - phpenv config-rm xdebug.ini || true
   - pecl install -f mongodb-stable
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - composer selfupdate
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - travis_retry composer self-update
 
 install:
-  - composer config "platform.ext-mongo" "1.6.16" && composer require alcaeus/mongo-php-adapter --prefer-dist --no-interaction $COMPOSER_FLAGS
-  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - composer global require --no-scripts --no-plugins symfony/flex
+  - if [[ $TRAVIS_PHP_VERSION == 7.1 ]]; then composer require --no-update alcaeus/mongo-php-adapter; fi
+  - composer update $COMPOSER_FLAGS
 
 script:
   - ./bin/phpspec run -fpretty --verbose

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,29 @@
     "MIT"
   ],
   "require" : {
-    "php": "^5.5.9|>=7.0.8",
-    "symfony/framework-bundle": "~3.4|~4.0|~5.0",
-    "symfony/validator": "~3.4|~4.0|~5.0",
-    "lexik/jwt-authentication-bundle": "^1.1|^2.0@dev"
+    "php": ">=7.1.3",
+    "lexik/jwt-authentication-bundle": "^1.1|^2.0",
+    "symfony/config": "^3.4|^4.4|^5.2",
+    "symfony/console": "^3.4|^4.4|^5.2",
+    "symfony/dependency-injection": "^3.4.27|^4.4|^5.2",
+    "symfony/event-dispatcher": "^3.4|^4.4|^5.2",
+    "symfony/http-foundation": "^3.4|^4.4|^5.2",
+    "symfony/http-kernel": "^3.4|^4.4|^5.2",
+    "symfony/property-access": "^3.4|^4.4|^5.2",
+    "symfony/security-core": "^3.4|^4.4|^5.2",
+    "symfony/security-guard": "^3.4|^4.4|^5.2",
+    "symfony/security-http": "^3.4|^4.4|^5.2",
+    "symfony/validator": "^3.4|^4.4|^5.2"
   },
   "require-dev": {
-    "doctrine/doctrine-bundle": "~1.4|~2.0",
+    "doctrine/doctrine-bundle": "^1.4|^2.0",
     "doctrine/mongodb-odm-bundle": "^3.4|^4.0",
+    "doctrine/persistence": "^1.3.3|^2.0",
     "doctrine/orm": "^2.4.8",
-    "phpspec/phpspec": "^3.0|^4.0|^5.0|^6.0"
+    "phpspec/phpspec": "^3.0|^4.0|^5.0|^6.0|^7.0"
+  },
+  "conflict": {
+    "doctrine/persistence": "<1.3.3"
   },
   "config": {
     "bin-dir": "bin"

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -21,3 +21,5 @@ code_coverage:
   output:
     clover: coverage.xml
     html: coverage
+
+runner.maintainers.errors.level: 14335 # E_ALL & ~E_USER_DEPRECATED ^ E_STRICT


### PR DESCRIPTION
Composer lists PHP 5.5 as the minimum supported version, yet this isn't actually tested.  So, I've bumped the PHP minimum up to 7.1.3 which matches Symfony 4 and the lowest tested PHP version.  This also helps unblock bringing in new code to address Symfony 5.3 deprecations.

I've also tightened the supported Symfony version list up so now only the 3.4 and 4.4 LTS' are supported, as well as only `^5.2` (this effectively drops 4.0-3 and 5.0-1).

The dependency list is updated to list out all of the actual dependencies instead of relying on transient dependencies to bring them in.

For CI, the matrix is updated to test PHP 7.4 and 8.0 (previously untested), to use Flex for restricting the Symfony version range (which avoids needing to install the `symfony/symfony` monorepo, which hid the broken dependency list), and makes sure all supported Symfony versions are tested.  There is also now a `--prefer-lowest` build in the queue to ensure the minimum dependencies are valid.

(On a side note, migrating to GitHub Actions would be a good idea here too)