### PR TITLE
Restore accidentally removed Doctrine configs

### DIFF
--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,7 +5,7 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken">
+    <document name="Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken" collection="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Document\RefreshTokenRepository">
         <field field-name="id" type="id" />
         <field field-name="refreshToken" type="string" unique="true" />
         <field field-name="username" type="string" />

--- a/Resources/config/doctrine/RefreshToken.orm.xml
+++ b/Resources/config/doctrine/RefreshToken.orm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken" table="refresh_tokens">
+    <entity name="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken" table="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository">
         <id name="id" type="integer">
             <generator strategy="AUTO"/>
         </id>


### PR DESCRIPTION
In consolidating things, I managed to accidentally remove a couple of the attributes to configure the Doctrine resources.  Those are restored.