### PR TITLE
Bump minimum PHP to 7.4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
         symfony: [3.4.*, 4.4.*, 5.2.*, 5.3.*]
         composer-flags: ['--prefer-stable']
         can-fail: [false]
         include:
-          - php: 7.1
+          - php: 7.4
             symfony: 3.4.*
             composer-flags: '--prefer-stable --prefer-lowest'
             can-fail: false
@@ -25,10 +25,6 @@ jobs:
         exclude:
           - php: 8.0
             symfony: 3.4.*
-          - php: 7.1
-            symfony: 5.2.*
-          - php: 7.1
-            symfony: 5.3.*
 
     name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 
@@ -49,11 +45,6 @@ jobs:
           tools: composer:v2
           extensions: curl, iconv, mbstring, mongodb, pdo, pdo_sqlite, sqlite, zip
           coverage: none
-
-      - name: Install Mongo PHP adapter
-        if: matrix.php == '7.1'
-        run: |
-          composer require --dev --no-update alcaeus/mongo-php-adapter
 
       - name: Install dependencies
         run: |

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "MIT"
   ],
   "require" : {
-    "php": ">=7.1.3",
+    "php": ">=7.4",
     "lexik/jwt-authentication-bundle": "^1.1|^2.0",
     "symfony/config": "^3.4|^4.4|^5.2",
     "symfony/console": "^3.4|^4.4|^5.2",


### PR DESCRIPTION
Looking at the [PHP version stats](https://packagist.org/packages/gesdinet/jwt-refresh-token-bundle/php-stats) for the bundle's installs, the majority of PHP 7.3 and earlier installs look to come from older bundle versions.  Roughly 90% of all installs of 0.12 are PHP 7.4+ users.  So, this proposes bumping the PHP requirement up to 7.4 since the stats seem to show a trend of users using the current version of the bundle are also using current PHP versions.