### PR TITLE
Don't mark extractor services as public

### DIFF
--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -67,12 +67,10 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('gesdinet.jwtrefreshtoken.request.extractor.request_body')
         ->class(RequestBodyExtractor::class)
-        ->public()
         ->tag('gesdinet_jwt_refresh_token.request_extractor');
 
     $services->set('gesdinet.jwtrefreshtoken.request.extractor.request_parameter')
         ->class(RequestParameterExtractor::class)
-        ->public()
         ->tag('gesdinet_jwt_refresh_token.request_extractor');
 
     $services->set('gesdinet.jwtrefreshtoken')


### PR DESCRIPTION
As pointed out at https://github.com/markitosgv/JWTRefreshTokenBundle/pull/256#pullrequestreview-708191005 the extractors are public services, they don't need to be here.