### PR TITLE
Don't use deprecated base RefreshTokenManager class

### DIFF
--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -13,10 +13,11 @@ namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
 use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
-use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager as BaseRefreshTokenManager;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
 
-class RefreshTokenManager extends BaseRefreshTokenManager
+class RefreshTokenManager implements RefreshTokenManagerInterface
 {
     /**
      * @var ObjectManager
@@ -42,6 +43,22 @@ class RefreshTokenManager extends BaseRefreshTokenManager
         $this->repository = $om->getRepository($class);
         $metadata = $om->getClassMetadata($class);
         $this->class = $metadata->getName();
+    }
+
+    /**
+     * Creates an empty RefreshTokenInterface instance.
+     *
+     * @return RefreshTokenInterface
+     *
+     * @deprecated to be removed in 2.0, use a `Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface` instead.
+     */
+    public function create()
+    {
+        trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', '%s() is deprecated and will be removed in 2.0, use a "%s" instance to create new %s objects.', __METHOD__, RefreshTokenGeneratorInterface::class, RefreshTokenInterface::class);
+
+        $class = $this->getClass();
+
+        return new $class();
     }
 
     /**

--- a/Model/RefreshTokenManager.php
+++ b/Model/RefreshTokenManager.php
@@ -11,6 +11,8 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Model;
 
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
+
 trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class is deprecated, implement "%s" directly.', RefreshTokenManager::class, RefreshTokenManagerInterface::class);
 
 /**
@@ -19,12 +21,16 @@ trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class 
 abstract class RefreshTokenManager implements RefreshTokenManagerInterface
 {
     /**
-     * Creates an empty RefreshToken instance.
+     * Creates an empty RefreshTokenInterface instance.
      *
      * @return RefreshTokenInterface
+     *
+     * @deprecated to be removed in 2.0, use a `Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface` instead.
      */
     public function create()
     {
+        trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', '%s() is deprecated and will be removed in 2.0, use a "%s" instance to create new %s objects.', __METHOD__, RefreshTokenGeneratorInterface::class, RefreshTokenInterface::class);
+
         $class = $this->getClass();
 
         return new $class();

--- a/Model/RefreshTokenManagerInterface.php
+++ b/Model/RefreshTokenManagerInterface.php
@@ -20,7 +20,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\Model;
 interface RefreshTokenManagerInterface
 {
     /**
-     * Creates an empty refresh token instance.
+     * Creates an empty RefreshTokenInterface instance.
      *
      * @return RefreshTokenInterface
      *


### PR DESCRIPTION
As pointed out in https://github.com/markitosgv/JWTRefreshTokenBundle/issues/255#issuecomment-881057800 having the Doctrine refresh manager extend the deprecated base refresh manager class is triggering unsolvable deprecations for bundle users.  This avoids the deprecation by having the class implement the interface directly instead of extending from the deprecated class.

Note, technically this is a minor B/C break as it breaks type assertions (typehinting or checking against the concrete `Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager` instead of `Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface`), but at that point I'd argue that downstream users probably have broken type checks in their apps anyway if they're actually relying on that implementation detail.