### PR TITLE
Add various fixes from PHPStan analysis

### DIFF
--- a/Command/ClearInvalidRefreshTokensCommand.php
+++ b/Command/ClearInvalidRefreshTokensCommand.php
@@ -39,6 +39,7 @@ class ClearInvalidRefreshTokensCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string|null $datetime */
         $datetime = $input->getArgument('datetime');
 
         if (null === $datetime) {

--- a/Command/RevokeRefreshTokenCommand.php
+++ b/Command/RevokeRefreshTokenCommand.php
@@ -39,6 +39,7 @@ class RevokeRefreshTokenCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var string $refreshTokenParam */
         $refreshTokenParam = $input->getArgument('refresh_token');
 
         $refreshToken = $this->refreshTokenManager->get($refreshTokenParam);

--- a/DependencyInjection/Compiler/AddExtractorsToChainCompilerPass.php
+++ b/DependencyInjection/Compiler/AddExtractorsToChainCompilerPass.php
@@ -10,7 +10,7 @@ final class AddExtractorsToChainCompilerPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('gesdinet.jwtrefreshtoken.request.extractor.chain')) {
             return;

--- a/DependencyInjection/Compiler/CustomUserProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/CustomUserProviderCompilerPass.php
@@ -22,12 +22,13 @@ final class CustomUserProviderCompilerPass implements CompilerPassInterface
         $this->internalUse = $internalUse;
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $this->internalUse) {
             trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class is deprecated.', self::class);
         }
 
+        /** @var string|null $customUserProvider */
         $customUserProvider = $container->getParameter('gesdinet_jwt_refresh_token.user_provider');
         if (!$customUserProvider) {
             return;
@@ -40,7 +41,7 @@ final class CustomUserProviderCompilerPass implements CompilerPassInterface
 
         $definition->addMethodCall(
             'setCustomUserProvider',
-            [new Reference($customUserProvider, ContainerInterface::NULL_ON_INVALID_REFERENCE, false)]
+            [new Reference($customUserProvider, ContainerInterface::NULL_ON_INVALID_REFERENCE)]
         );
     }
 }

--- a/DependencyInjection/Compiler/ObjectManagerCompilerPass.php
+++ b/DependencyInjection/Compiler/ObjectManagerCompilerPass.php
@@ -7,8 +7,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class ObjectManagerCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
+        /** @var string|null $objectManagerId */
         $objectManagerId = $container->getParameter('gesdinet.jwtrefreshtoken.object_manager.id');
         if (!$objectManagerId) {
             return;

--- a/DependencyInjection/Compiler/UserCheckerCompilerPass.php
+++ b/DependencyInjection/Compiler/UserCheckerCompilerPass.php
@@ -20,12 +20,13 @@ final class UserCheckerCompilerPass implements CompilerPassInterface
         $this->internalUse = $internalUse;
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $this->internalUse) {
             trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class is deprecated.', self::class);
         }
 
+        /** @var string|null $userCheckerId */
         $userCheckerId = $container->getParameter('gesdinet.jwtrefreshtoken.user_checker.id');
         if (!$userCheckerId) {
             return;

--- a/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
@@ -37,10 +37,10 @@ final class RefreshTokenAuthenticatorFactory implements SecurityFactoryInterface
         return 'refresh-jwt';
     }
 
-    public function addConfiguration(NodeDefinition $node): void
+    public function addConfiguration(NodeDefinition $builder): void
     {
         // no-op TTL and param configuration until bundle is further updated to support per-authenticator configuration
-        $node
+        $builder
             ->children()
                 ->scalarNode('provider')->end()
                 ->scalarNode('success_handler')->end()

--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -24,7 +24,7 @@ class RefreshTokenManager extends BaseRefreshTokenManager
     protected $objectManager;
 
     /**
-     * @var string
+     * @var class-string<RefreshTokenInterface>
      */
     protected $class;
 
@@ -65,7 +65,9 @@ class RefreshTokenManager extends BaseRefreshTokenManager
     }
 
     /**
-     * @param bool|true $andFlush
+     * @param bool $andFlush
+     *
+     * @return void
      */
     public function save(RefreshTokenInterface $refreshToken, $andFlush = true)
     {
@@ -78,6 +80,8 @@ class RefreshTokenManager extends BaseRefreshTokenManager
 
     /**
      * @param bool $andFlush
+     *
+     * @return void
      */
     public function delete(RefreshTokenInterface $refreshToken, $andFlush = true)
     {

--- a/Document/RefreshTokenRepository.php
+++ b/Document/RefreshTokenRepository.php
@@ -7,17 +7,31 @@ use Doctrine\ODM\MongoDB\Repository\DocumentRepository as MongoDBDocumentReposit
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 
 if (class_exists(MongoDBDocumentRepository::class)) {
-    // Support for doctrine/mongodb-odm >= 2.0
+    /**
+     * Internal repository supporting doctrine/mongodb-odm >=2.0.
+     *
+     * @template T of object
+     * @extends MongoDBDocumentRepository<T>
+     *
+     * @internal
+     */
     class BaseRepository extends MongoDBDocumentRepository
     {
     }
 } else {
-    // Support for doctrine/mongodb-odm < 2.0
+    /**
+     * Internal repository supporting doctrine/mongodb-odm <2.0.
+     *
+     * @internal
+     */
     class BaseRepository extends DocumentRepository
     {
     }
 }
 
+/**
+ * @extends BaseRepository<RefreshToken>
+ */
 class RefreshTokenRepository extends BaseRepository
 {
     /**

--- a/Entity/RefreshTokenRepository.php
+++ b/Entity/RefreshTokenRepository.php
@@ -5,6 +5,9 @@ namespace Gesdinet\JWTRefreshTokenBundle\Entity;
 use Doctrine\ORM\EntityRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 
+/**
+ * @extends EntityRepository<RefreshToken>
+ */
 class RefreshTokenRepository extends EntityRepository
 {
     /**

--- a/Event/Event.php
+++ b/Event/Event.php
@@ -8,10 +8,20 @@ use Symfony\Contracts\EventDispatcher\Event as ContractsBaseEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 if (is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
+    /**
+     * Internal event class supporting symfony/event-dispatcher >=4.3.
+     *
+     * @internal
+     */
     class Event extends ContractsBaseEvent
     {
     }
 } else {
+    /**
+     * Internal event class supporting symfony/event-dispatcher <4.3.
+     *
+     * @internal
+     */
     class Event extends BaseEvent
     {
     }

--- a/GesdinetJWTRefreshTokenBundle.php
+++ b/GesdinetJWTRefreshTokenBundle.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 
 class GesdinetJWTRefreshTokenBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Model/AbstractRefreshToken.php
+++ b/Model/AbstractRefreshToken.php
@@ -21,17 +21,17 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     protected $id;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $refreshToken;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $username;
 
     /**
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      */
     protected $valid;
 

--- a/Model/RefreshTokenInterface.php
+++ b/Model/RefreshTokenInterface.php
@@ -33,7 +33,7 @@ interface RefreshTokenInterface
     public function setRefreshToken($refreshToken = null);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getRefreshToken();
 

--- a/Model/RefreshTokenManagerInterface.php
+++ b/Model/RefreshTokenManagerInterface.php
@@ -42,8 +42,14 @@ interface RefreshTokenManagerInterface
      */
     public function getLastFromUsername($username);
 
+    /**
+     * @return void
+     */
     public function save(RefreshTokenInterface $refreshToken);
 
+    /**
+     * @return void
+     */
     public function delete(RefreshTokenInterface $refreshToken);
 
     /**

--- a/Security/Http/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Http/Authenticator/RefreshTokenAuthenticator.php
@@ -148,7 +148,7 @@ class RefreshTokenAuthenticator extends AbstractAuthenticator implements Authent
     {
         $event = new RefreshTokenNotFoundEvent(
             new MissingTokenException('JWT Refresh Token not found', 0, $authException),
-            new RefreshAuthenticationFailureResponse($authException->getMessageKey())
+            new RefreshAuthenticationFailureResponse($authException ? $authException->getMessageKey() : 'Authentication error')
         );
 
         $this->eventDispatcher->dispatch($event, 'gesdinet.refresh_token_not_found');

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -41,6 +41,9 @@ class RefreshTokenProvider implements UserProviderInterface
         $this->refreshTokenManager = $refreshTokenManager;
     }
 
+    /**
+     * @return void
+     */
     public function setCustomUserProvider(UserProviderInterface $customUserProvider)
     {
         $this->customUserProvider = $customUserProvider;

--- a/Service/RefreshToken.php
+++ b/Service/RefreshToken.php
@@ -103,7 +103,7 @@ class RefreshToken
             return $this->failureHandler->onAuthenticationFailure(
                 $request,
                 new InvalidRefreshTokenException(
-                    sprintf('Refresh token "%s" is invalid.', $refreshToken)
+                    sprintf('Refresh token "%s" is invalid.', (string) $refreshToken)
                 )
             );
         }


### PR DESCRIPTION
This is mostly docblock related adjustments, but there are a couple of interesting bits here:

- Adds generics annotations to the repository classes
- A user provider's `loadUserByUsername` or `loadUserByIdentifier` method doesn't have a nullable return, they are supposed to throw when the user isn't found; the older authentication class used a null check where it doesn't apply