### PR TITLE
Require refresh token models to be Stringable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
     - `Gesdinet\JWTRefreshTokenBundle\Request\Extractor\RequestBodyExtractor` - Decodes a JSON request body and loads the token from it
     - `Gesdinet\JWTRefreshTokenBundle\Request\Extractor\RequestParameterExtractor` - Loads the refresh token by calling `$request->get()`
 - Removed the `Gesdinet\JWTRefreshTokenBundle\Request\RequestRefreshToken` class, a `Gesdinet\JWTRefreshTokenBundle\Request\Extractor\ExtractorInterface` implementation should be used instead
+- `Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface` now extends `Stringable`, refresh token models now require a `__toString()` method

--- a/Model/RefreshTokenInterface.php
+++ b/Model/RefreshTokenInterface.php
@@ -13,7 +13,7 @@ namespace Gesdinet\JWTRefreshTokenBundle\Model;
 
 use Symfony\Component\Security\Core\User\UserInterface;
 
-interface RefreshTokenInterface
+interface RefreshTokenInterface extends \Stringable
 {
     /**
      * Creates a new model instance based on the provided details.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "symfony/event-dispatcher": "^3.4|^4.4|^5.2",
     "symfony/http-foundation": "^3.4|^4.4|^5.2",
     "symfony/http-kernel": "^3.4|^4.4|^5.2",
+    "symfony/polyfill-php80": "^1.15",
     "symfony/property-access": "^3.4|^4.4|^5.2",
     "symfony/security-bundle": "^3.4|^4.0|^5.2",
     "symfony/security-core": "^3.4|^4.4|^5.2",


### PR DESCRIPTION
The `AbstractRefreshToken` class adds `__toString()` to make the token models stringable (i.e. `(string) $token`).  PHP 8 adds the `Stringable` interface to require this, and Symfony polyfills the interface for PHP 7.  So, let's make this a hard requirement for the `RefreshTokenInterface`.