### PR TITLE
Fix DI error

### DIFF
--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -99,6 +99,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             new Reference('gesdinet.jwtrefreshtoken.user_checker'),
             new Parameter('gesdinet_jwt_refresh_token.token_parameter_name'),
+            new Reference('gesdinet.jwtrefreshtoken.request.extractor.chain'),
         ]);
 
     $services->set('gesdinet.jwtrefreshtoken.security.authentication.failure_handler')


### PR DESCRIPTION
```
Too few arguments to function Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthenticator::__construct(), 2 passed in <project_path>/var/cache/dev/ContainerAv4TZ3Z/getGesdinet_Jwtrefreshtoken_AuthenticatorService.php on line 27 and exactly 3 expected
```