### PR TITLE
Updates based on Symfony 5.4 Security component deprecations

### DIFF
--- a/DependencyInjection/Security/Factory/LegacyRefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/LegacyRefreshTokenAuthenticatorFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the GesdinetJWTRefreshTokenBundle package.
+ *
+ * (c) Gesdinet <http://www.gesdinet.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class is deprecated, use "%s" instead.', LegacyRefreshTokenAuthenticatorFactory::class, RefreshTokenAuthenticatorFactory::class);
+
+/**
+ * @deprecated to be removed in 2.0, use `Gesdinet\JWTRefreshTokenBundle\Security\Factory\RefreshTokenAuthenticatorFactory` instead.
+ */
+final class LegacyRefreshTokenAuthenticatorFactory extends RefreshTokenAuthenticatorFactory implements SecurityFactoryInterface
+{
+    public function create(ContainerBuilder $container, string $id, array $config, string $userProviderId, ?string $defaultEntryPointId): array
+    {
+        // Does not support the legacy authentication system
+        return [];
+    }
+
+    public function getPosition(): string
+    {
+        return 'http';
+    }
+}

--- a/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
@@ -12,24 +12,20 @@
 namespace Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
-final class RefreshTokenAuthenticatorFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
+/**
+ * @final
+ */
+/* final */ class RefreshTokenAuthenticatorFactory implements AuthenticatorFactoryInterface
 {
-    public function create(ContainerBuilder $container, string $id, array $config, string $userProviderId, ?string $defaultEntryPointId): array
+    public function getPriority(): int
     {
-        // Does not support the legacy authentication system
-        return [];
-    }
-
-    public function getPosition(): string
-    {
-        return 'http';
+        return -50;
     }
 
     public function getKey(): string

--- a/GesdinetJWTRefreshTokenBundle.php
+++ b/GesdinetJWTRefreshTokenBundle.php
@@ -6,6 +6,7 @@ use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\AddExtractorsToC
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\CustomUserProviderCompilerPass;
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\ObjectManagerCompilerPass;
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Compiler\UserCheckerCompilerPass;
+use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Security\Factory\LegacyRefreshTokenAuthenticatorFactory;
 use Gesdinet\JWTRefreshTokenBundle\DependencyInjection\Security\Factory\RefreshTokenAuthenticatorFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,7 +28,12 @@ class GesdinetJWTRefreshTokenBundle extends Bundle
         if (interface_exists(RememberMeHandlerInterface::class)) {
             /** @var SecurityExtension $extension */
             $extension = $container->getExtension('security');
-            $extension->addSecurityListenerFactory(new RefreshTokenAuthenticatorFactory());
+
+            if (method_exists($extension, 'addAuthenticatorFactory')) {
+                $extension->addAuthenticatorFactory(new RefreshTokenAuthenticatorFactory());
+            } else {
+                $extension->addSecurityListenerFactory(new LegacyRefreshTokenAuthenticatorFactory());
+            }
         }
     }
 }

--- a/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
+++ b/spec/Security/Authenticator/RefreshTokenAuthenticatorSpec.php
@@ -13,6 +13,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
+/**
+ * @require Symfony\Component\Security\Guard\AbstractGuardAuthenticator
+ */
 class RefreshTokenAuthenticatorSpec extends ObjectBehavior
 {
     private const PARAMETER_NAME = 'refresh_token';


### PR DESCRIPTION
This aims to add the compatibility layer needed for Security component deprecations introduced in Symfony 5.4, all of which will be removed in 6.0.

Upstream changes covered in this PR include:

- https://github.com/symfony/symfony/pull/41754
- https://github.com/symfony/symfony/pull/42198