### PR TITLE
Bump minimum PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,10 @@
     "doctrine/mongodb-odm-bundle": "^3.4|^4.0",
     "doctrine/persistence": "^1.3.3|^2.0",
     "doctrine/orm": "^2.7",
-    "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+    "matthiasnoback/symfony-config-test": "^4.2",
+    "matthiasnoback/symfony-dependency-injection-test": "^4.2",
     "phpspec/phpspec": "^7.0",
-    "phpunit/phpunit": "^8.5|^9.5",
+    "phpunit/phpunit": "^9.5",
     "symfony/cache": "^3.4|^4.4|^5.2"
   },
   "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,17 +11,17 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>.</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./spec</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./spec</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 
     <php>
         <const name="JWTREFRESHTOKENBUNDLE_MONGODB_SERVER" value="mongodb://localhost:27017" />


### PR DESCRIPTION
There isn't much of a need to use PHPUnit 8 anymore, so drop it from the list.