### PR TITLE
Move service deprecations into config file

### DIFF
--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -17,18 +17,11 @@ use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as RefreshTokenEntity;
 use Gesdinet\JWTRefreshTokenBundle\Request\Extractor\ExtractorInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 class GesdinetJWTRefreshTokenExtension extends Extension
 {
-    private const DEPRECATED_SERVICES = [
-        'gesdinet.jwtrefreshtoken' => '1.0',
-        'gesdinet.jwtrefreshtoken.authenticator' => '1.0',
-        'gesdinet.jwtrefreshtoken.user_provider' => '1.0',
-    ];
-
     public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
@@ -66,34 +59,6 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet.jwtrefreshtoken.refresh_token.class', $refreshTokenClass);
         $container->setParameter('gesdinet.jwtrefreshtoken.object_manager.id', $objectManager);
         $container->setParameter('gesdinet.jwtrefreshtoken.user_checker.id', $config['user_checker']);
-
-        $this->deprecateServices($container);
-    }
-
-    private function deprecateServices(ContainerBuilder $container): void
-    {
-        $usesSymfony51Api = method_exists(Definition::class, 'getDeprecation');
-
-        foreach (self::DEPRECATED_SERVICES as $serviceId => $deprecatedSince) {
-            if (!$container->hasDefinition($serviceId)) {
-                continue;
-            }
-
-            $service = $container->getDefinition($serviceId);
-
-            if ($usesSymfony51Api) {
-                $service->setDeprecated(
-                    'gesdinet/jwt-refresh-token-bundle',
-                    $deprecatedSince,
-                    'The "%service_id%" service is deprecated.'
-                );
-            } else {
-                $service->setDeprecated(
-                    true,
-                    'The "%service_id%" service is deprecated.'
-                );
-            }
-        }
     }
 
     /**

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -17,11 +17,20 @@ use Gesdinet\JWTRefreshTokenBundle\Security\Authenticator\RefreshTokenAuthentica
 use Gesdinet\JWTRefreshTokenBundle\Security\Http\Authenticator\RefreshTokenAuthenticator;
 use Gesdinet\JWTRefreshTokenBundle\Security\Provider\RefreshTokenProvider;
 use Gesdinet\JWTRefreshTokenBundle\Service\RefreshToken;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
 return static function (ContainerConfigurator $container) {
+    $deprecateArgs = static function (string $version, string $message = 'The "%service_id%" service is deprecated.'): array {
+        if (method_exists(Definition::class, 'getDeprecation')) {
+            return ['gesdinet/jwt-refresh-token-bundle', $version, $message];
+        }
+
+        return [$message];
+    };
+
     $services = $container->services();
 
     $services->set('gesdinet.jwtrefreshtoken.send_token')
@@ -74,6 +83,7 @@ return static function (ContainerConfigurator $container) {
         ->tag('gesdinet_jwt_refresh_token.request_extractor');
 
     $services->set('gesdinet.jwtrefreshtoken')
+        ->deprecate(...$deprecateArgs('1.0'))
         ->class(RefreshToken::class)
         ->public()
         ->args([
@@ -89,12 +99,14 @@ return static function (ContainerConfigurator $container) {
         ]);
 
     $services->set('gesdinet.jwtrefreshtoken.user_provider')
+        ->deprecate(...$deprecateArgs('1.0'))
         ->class(RefreshTokenProvider::class)
         ->args([
             new Reference('gesdinet.jwtrefreshtoken.refresh_token_manager'),
         ]);
 
     $services->set('gesdinet.jwtrefreshtoken.authenticator')
+        ->deprecate(...$deprecateArgs('1.0'))
         ->class(LegacyRefreshTokenAuthenticator::class)
         ->args([
             new Reference('gesdinet.jwtrefreshtoken.user_checker'),


### PR DESCRIPTION
With PHP service configs being used, service deprecations (including the B/C layer for changed signatures in Symfony 5.1) can be handled cleanly all in the same file.  So, move the deprecation logic from the container extension to the config file.