### PR TITLE
Fixes #287 - Add LogoutEventListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Dropped support for MongoDB ODM 1.x
 - Dropped support for Symfony 3.4
 - Added support for Symfony 6.0
+- Added a LogoutEventListener that will invalidate the supplied refresh token and clear the cookie (if configured) when a LogoutEvent is triggered on the configured firewall.
 
 ## 1.0.0-beta4
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -98,6 +98,10 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('remove_token_from_body')->defaultTrue()->end()
                     ->end()
                 ->end()
+                ->scalarNode('logout_firewall')
+                    ->defaultValue('api')
+                    ->info('Name of the firewall that triggers the logout event to hook into (default: api)')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -41,6 +41,10 @@ class GesdinetJWTRefreshTokenExtension extends Extension
         $container->setParameter('gesdinet_jwt_refresh_token.token_parameter_name', $config['token_parameter_name']);
         $container->setParameter('gesdinet_jwt_refresh_token.doctrine_mappings', $config['doctrine_mappings']);
         $container->setParameter('gesdinet_jwt_refresh_token.cookie', $config['cookie'] ?? []);
+        $container->setParameter('gesdinet_jwt_refresh_token.logout_firewall_context', sprintf(
+            'security.firewall.map.context.%s',
+            $config['logout_firewall']
+        ));
 
         $refreshTokenClass = RefreshTokenEntity::class;
         $objectManager = 'doctrine.orm.entity_manager';

--- a/EventListener/LogoutEventListener.php
+++ b/EventListener/LogoutEventListener.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the GesdinetJWTRefreshTokenBundle package.
+ *
+ * (c) Gesdinet <http://www.gesdinet.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gesdinet\JWTRefreshTokenBundle\EventListener;
+
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Gesdinet\JWTRefreshTokenBundle\Request\Extractor\ExtractorInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+class LogoutEventListener
+{
+    private RefreshTokenManagerInterface $refreshTokenManager;
+    private ExtractorInterface $refreshTokenExtractor;
+    private string $tokenParameterName;
+    private array $cookieSettings;
+    private string $logout_firewall_context;
+
+    public function __construct(
+        RefreshTokenManagerInterface $refreshTokenManager,
+        ExtractorInterface $refreshTokenExtractor,
+        string $tokenParameterName,
+        array $cookieSettings,
+        string $logout_firewall_context,
+    ) {
+        $this->refreshTokenManager = $refreshTokenManager;
+        $this->refreshTokenExtractor = $refreshTokenExtractor;
+        $this->tokenParameterName = $tokenParameterName;
+        $this->cookieSettings = array_merge([
+            'enabled' => false,
+            'same_site' => 'lax',
+            'path' => '/',
+            'domain' => null,
+            'http_only' => true,
+            'secure' => true,
+            'remove_token_from_body' => true,
+        ], $cookieSettings);
+        $this->logout_firewall_context = $logout_firewall_context;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        $request = $event->getRequest();
+        $current_firewall_context = $request->attributes->get('_firewall_context');
+
+        if ($current_firewall_context !== $this->logout_firewall_context) {
+            return;
+        }
+
+        $tokenString = $this->refreshTokenExtractor->getRefreshToken($request, $this->tokenParameterName);
+        if (null === $tokenString) {
+            $event->setResponse(
+                new JsonResponse(
+                    [
+                        'code' => 400,
+                        'message' => 'No refresh_token found.',
+                    ],
+                    JsonResponse::HTTP_BAD_REQUEST
+                )
+            );
+
+            return;
+        } else {
+            $refreshToken = $this->refreshTokenManager->get($tokenString);
+            if (null === $refreshToken) {
+                $event->setResponse(
+                    new JsonResponse(
+                        [
+                            'code' => 200,
+                            'message' => 'The supplied refresh_token is already invalid.',
+                        ],
+                        JsonResponse::HTTP_OK
+                    )
+                );
+            } else {
+                $this->refreshTokenManager->delete($refreshToken);
+                $event->setResponse(
+                    new JsonResponse(
+                        [
+                            'code' => 200,
+                            'message' => 'The supplied refresh_token has been invalidated.',
+                        ],
+                        JsonResponse::HTTP_OK
+                    )
+                );
+            }
+        }
+
+        if ($this->cookieSettings['enabled']) {
+            $response = $event->getResponse();
+            $response->headers->clearCookie(
+                $this->tokenParameterName,
+                $this->cookieSettings['path'],
+                $this->cookieSettings['domain'],
+                $this->cookieSettings['secure'],
+                $this->cookieSettings['http_only'],
+                $this->cookieSettings['same_site']
+            );
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ gesdinet_jwt_refresh_token:
 
 By default, the refresh token is returned in the body of a JSON response. You can use the following configuration to set it in a HttpOnly cookie instead. The refresh token is automatically extracted from the cookie during refresh.
 
+To allow users to logout when using cookies, you need to [configure the `LogoutEvent` to trigger on a specific route](#invalidate-refresh-token-on-logout), and call that route during logout.
+
 ```yaml
 gesdinet_jwt_refresh_token:
     cookie:
@@ -315,6 +317,50 @@ gesdinet_jwt_refresh_token:
       http_only: true              # default value
       secure: true                 # default value
       remove_token_from_body: true # default value
+```
+
+### Invalidate refresh token on logout
+
+This bundle automatically registers an `EventListener` which triggers on `LogoutEvent`s from a specific firewall (default: `api`).
+
+The `LogoutEventListener` automatically invalidates the given refresh token and, if enabled, unsets the cookie.
+If no refresh token is supplied, an error is returned and the cookie remains untouched. If the supplied refresh token is (already) invalid, the cookie is unset.
+
+All you have to do is make sure the `LogoutEvent` triggers on a specific route, and call that route during logout:
+
+```yaml
+# in security.yaml
+security:
+    firewalls:
+        api:
+            logout:
+                path: api_token_invalidate
+```
+```yaml
+# in routes.yaml
+api_token_invalidate:
+    path: /api/token/invalidate
+```
+
+If you want to configure the `LogoutEvent` to trigger on a different firewall, the name of the firewall has to be configured:
+
+```yaml
+# in security.yaml
+security:
+    firewalls:
+        myfirewall:
+            logout:
+                path: api_token_invalidate
+```
+```yaml
+# in routes.yaml
+api_token_invalidate:
+    path: /api/token/invalidate
+```
+```yaml
+# in gesdinet_jwt_refresh_token.yaml
+gesdinet_jwt_refresh_token:
+    logout_firewall: myfirewall
 ```
 
 ### Doctrine Manager Type

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -4,6 +4,7 @@ use Gesdinet\JWTRefreshTokenBundle\Command\ClearInvalidRefreshTokensCommand;
 use Gesdinet\JWTRefreshTokenBundle\Command\RevokeRefreshTokenCommand;
 use Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager;
 use Gesdinet\JWTRefreshTokenBundle\EventListener\AttachRefreshTokenOnSuccessListener;
+use Gesdinet\JWTRefreshTokenBundle\EventListener\LogoutEventListener;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGenerator;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
@@ -157,4 +158,17 @@ return static function (ContainerConfigurator $container) {
             new Reference('gesdinet.jwtrefreshtoken.refresh_token_manager'),
         ])
         ->tag('console.command');
+
+    $services->set(LogoutEventListener::class)
+        ->args([
+            new Reference('gesdinet.jwtrefreshtoken.refresh_token_manager'),
+            new Reference('gesdinet.jwtrefreshtoken.request.extractor.chain'),
+            new Parameter('gesdinet_jwt_refresh_token.token_parameter_name'),
+            new Parameter('gesdinet_jwt_refresh_token.cookie'),
+            new Parameter('gesdinet_jwt_refresh_token.logout_firewall_context'),
+        ])
+        ->tag('kernel.event_listener', [
+            'event' => 'Symfony\Component\Security\Http\Event\LogoutEvent',
+            'method' => 'onLogout',
+        ]);
 };


### PR DESCRIPTION
This commit introduces a `LogoutEventListener` which invalidates the given `refresh_token` and unsets the cookie, if enabled.

If no refresh token is supplied, an error is returned and the cookie remains untouched. If the supplied refresh token is (already) invalid, the cookie is unset.

Because the `LogoutEventListener` always sets a response, it would inhibit normal logout behavior and therefore should only run on a specifically configured firewall.

Therefore a new configuration option is introduced, called `logout_firewall`, which contains the name of the firewall that triggers the logout event we want to hook into (default: `api`).