### PR TITLE
Check the request path in the authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added support for checking the request path in the `refresh_jwt` authenticator
+- Deprecated not configuring the request path to check in the `refresh_jwt` authenticator
+
+## 1.0.0
+
 - Dropped support for MongoDB ODM 1.x
 - Dropped support for Symfony 3.4
 - Added support for Symfony 6.0

--- a/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
+++ b/DependencyInjection/Security/Factory/RefreshTokenAuthenticatorFactory.php
@@ -35,6 +35,19 @@ final class RefreshTokenAuthenticatorFactory implements AuthenticatorFactoryInte
         // no-op TTL and param configuration until bundle is further updated to support per-authenticator configuration
         $builder
             ->children()
+                ->scalarNode('check_path')
+                    ->defaultNull()
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool => null === $v)
+                        ->then(static function () {
+                            trigger_deprecation(
+                                'gesdinet/jwt-refresh-token-bundle',
+                                '1.1',
+                                'Not setting the "check_path" option for the "refresh_jwt" authenticator is deprecated, as of 2.0 the authenticator will only check the request path.'
+                            );
+                        })
+                    ->end()
+                ->end()
                 ->scalarNode('provider')->end()
                 ->scalarNode('success_handler')->end()
                 ->scalarNode('failure_handler')->end()
@@ -62,6 +75,7 @@ final class RefreshTokenAuthenticatorFactory implements AuthenticatorFactoryInte
 
         // When per-authenticator configuration is supported, this array should be updated to check the $config values before falling back to the bundle parameters
         $options = [
+            'check_path' => $config['check_path'] ?? null,
             'ttl' => new Parameter('gesdinet_jwt_refresh_token.ttl'),
             'ttl_update' => new Parameter('gesdinet_jwt_refresh_token.ttl_update'),
             'token_parameter_name' => new Parameter('gesdinet_jwt_refresh_token.token_parameter_name'),

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -32,6 +32,14 @@ return static function (ContainerConfigurator $container) {
         return [$message];
     };
 
+    $abstractArg = static function (string $description) {
+        if (function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg')) {
+            return \Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg($description);
+        }
+
+        return null;
+    };
+
     $services = $container->services();
 
     $services->set('gesdinet.jwtrefreshtoken.send_token')
@@ -140,10 +148,11 @@ return static function (ContainerConfigurator $container) {
             new Reference('gesdinet.jwtrefreshtoken.refresh_token_manager'),
             new Reference('event_dispatcher'),
             new Reference('gesdinet.jwtrefreshtoken.request.extractor.chain'),
-            null, // User provider parameter is replaced in the security factory, change to an abstract argument reference when Symfony 5.1 and newer are required
-            null, // Success handler parameter is replaced in the security factory, change to an abstract argument reference when Symfony 5.1 and newer are required
-            null, // Failure handler parameter is replaced in the security factory, change to an abstract argument reference when Symfony 5.1 and newer are required
-            null, // Options parameter is replaced in the security factory, change to an abstract argument reference when Symfony 5.1 and newer are required
+            $abstractArg('user provider'),
+            $abstractArg('authentication success handler'),
+            $abstractArg('authentication failure handler'),
+            $abstractArg('options'),
+            new Reference('security.http_utils'),
         ]);
 
     $services->set(ClearInvalidRefreshTokensCommand::class)


### PR DESCRIPTION
Related to https://github.com/markitosgv/JWTRefreshTokenBundle/issues/255#issuecomment-1030286770 and some other comments and issues

This should improve the DX and the use of the authenticator with Symfony 5.4+ by making the authenticator check the request path instead of relying on the presence of the refresh token in the request.  Relying on the token being in the request to trigger the authenticator is deprecated with this PR and will be removed in 2.0 in favor of only matching the request path.

A nice side effect of this change is that the security configuration becomes much cleaner.  Using my tester app, I was able to simplify things down with [this commit](https://github.com/mbabker/refresh-token-tester/commit/3deb2497f7d8bfcaea4a4071a6cbae0aeb7b1c8f) and now all of my API related authentication is on one firewall instead of three.