### PR TITLE
[B/C Break] Change the object mappings to mapped superclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [B/C Break] Changed the object mappings to mapped superclasses, this requires updating your app's configuration
 - Added support for checking the request path in the `refresh_jwt` authenticator
 - Deprecated not configuring the request path to check in the `refresh_jwt` authenticator
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -52,6 +52,16 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('refresh_token_class')
                     ->defaultNull()
                     ->info(sprintf('Set the refresh token class to use (default: %s)', RefreshToken::class))
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool => null === $v)
+                        ->then(static function () {
+                            trigger_deprecation(
+                                'gesdinet/jwt-refresh-token-bundle',
+                                '1.1',
+                                'Not setting the "refresh_token_class" option is deprecated, as of 2.0 a class must be set.'
+                            );
+                        })
+                    ->end()
                 ->end()
                 ->scalarNode('object_manager')
                     ->defaultNull()

--- a/README.md
+++ b/README.md
@@ -75,7 +75,58 @@ return [
 ];
 ```
 
-### Step 3 (Symfony 5.4+)
+### Step 3: Configure the Bundle
+
+#### Symfony Flex Application
+
+For an application using Symfony Flex, a recipe should have been applied to your application. If not, you will need to make the following changes:
+
+1. Configure the refresh token class. Create the `config/packages/gesdinet_jwt_refresh_token.yaml` file with the below contents:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    refresh_token_class: App\Entity\RefreshToken # This is the class name of the refresh token, you will need to adjust this to match the class your application will use
+```
+
+2. Create the object class. 
+
+If you are using the Doctrine ORM, the below contents should be placed at `src/Entity/RefreshToken.php`:
+
+```php
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+
+/**
+ * @ORM\Entity
+ */
+class RefreshToken extends BaseRefreshToken
+{
+}
+```
+
+If you are using the Doctrine MongoDB ODM, the below contents should be placed at `src/Document/RefreshToken.php` (remember to update the `refresh_token_class` configuration above to match):
+
+```php
+<?php
+
+namespace App\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken as BaseRefreshToken;
+
+/**
+ * @ODM\Document
+ */
+class RefreshToken extends BaseRefreshToken
+{
+}
+```
+
+### Step 4 (Symfony 5.4+)
 
 #### Define the refresh token route
 
@@ -121,7 +172,7 @@ security:
 # ...
 ```
 
-### Step 3 (Symfony 4.4)
+### Step 4 (Symfony 4.4)
 
 #### Define the refresh token route
 
@@ -157,7 +208,7 @@ security:
 # ...
 ```
 
-### Step 4: Update your database schema
+### Step 5: Update your database schema
 
 You will need to add the table for the refresh tokens to your application's database.
 

--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,10 +5,10 @@
                         xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken" collection="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Document\RefreshTokenRepository">
+    <mapped-superclass name="Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken" collection="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Document\RefreshTokenRepository">
         <id />
         <field field-name="refreshToken" type="string" unique="true" />
         <field field-name="username" type="string" />
         <field field-name="valid" type="date"/>
-    </document>
+    </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/RefreshToken.orm.xml
+++ b/Resources/config/doctrine/RefreshToken.orm.xml
@@ -5,7 +5,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken" table="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository">
+    <mapped-superclass name="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken" table="refresh_tokens" repository-class="Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository">
         <id name="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
@@ -13,5 +13,5 @@
         <field name="refreshToken" type="string" column="refresh_token" length="128" unique="true"/>
         <field name="username" type="string" length="255" column="username"/>
         <field name="valid" type="datetime"/>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/Tests/Functional/Document/RefreshTokenRepositoryTest.php
+++ b/Tests/Functional/Document/RefreshTokenRepositoryTest.php
@@ -3,9 +3,9 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Document;
 
 use Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager;
-use Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Document\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGenerator;
+use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Document\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Document\User;
 use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\ODMTestCase;
 

--- a/Tests/Functional/Entity/RefreshTokenRepositoryTest.php
+++ b/Tests/Functional/Entity/RefreshTokenRepositoryTest.php
@@ -4,9 +4,9 @@ namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\Tools\SchemaTool;
 use Gesdinet\JWTRefreshTokenBundle\Doctrine\RefreshTokenManager;
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGenerator;
+use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Entity\User;
 use Gesdinet\JWTRefreshTokenBundle\Tests\Functional\ORMTestCase;
 

--- a/Tests/Functional/Fixtures/Document/RefreshToken.php
+++ b/Tests/Functional/Fixtures/Document/RefreshToken.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken as BaseRefreshToken;
+
+/**
+ * @ODM\Document
+ */
+class RefreshToken extends BaseRefreshToken
+{
+}

--- a/Tests/Functional/Fixtures/Entity/RefreshToken.php
+++ b/Tests/Functional/Fixtures/Entity/RefreshToken.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
+
+/**
+ * @ORM\Entity()
+ */
+class RefreshToken extends BaseRefreshToken
+{
+}


### PR DESCRIPTION
Fixes #285

This fixes the inability to customize the storage schema for the refresh token object (i.e. anything where you try to extend the provided Document or Entity classes to do things like change the table name or add fields).  Unfortunately, this does have a practical B/C break because when downstream users pull in the updated version with this change, they will need to make some changes in their application (specifically the bits noted in the updated README about configuring the bundle from the Flex recipe).

If accepted, I can get https://github.com/symfony/recipes-contrib/compare/master...mbabker:jwt-refresh-bundle submitted to add the needed recipe to the Flex contrib repo, which will also help new installs or anyone updating their app (and also allowing contrib recipes).