### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
   },
   "extra" : {
     "branch-alias" : {
-      "dev-master" : "1.0-dev"
+      "dev-master" : "1.x-dev"
     }
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
This will allow installing the master branch as `1.*@dev` instead of `~1.0@dev`