### PR TITLE
Expiration ttl parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for checking the request path in the `refresh_jwt` authenticator
 - Deprecated not configuring the request path to check in the `refresh_jwt` authenticator
+- Added feature to add the expiration timestamp on the response
 
 ## 1.0.0
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -102,6 +102,14 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('api')
                     ->info('Name of the firewall that triggers the logout event to hook into (default: api)')
                 ->end()
+                ->scalarNode('return_expiration')
+                    ->defaultFalse()
+                    ->info('When true, the response will include the token expiration timestamp')
+                ->end()
+                ->scalarNode('return_expiration_parameter_name')
+                    ->defaultValue('refresh_token_expiration')
+                    ->info('The default response parameter name containing the refresh token expiration timestamp')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -45,6 +45,8 @@ class GesdinetJWTRefreshTokenExtension extends Extension
             'security.firewall.map.context.%s',
             $config['logout_firewall']
         ));
+        $container->setParameter('gesdinet_jwt_refresh_token.return_expiration', $config['return_expiration']);
+        $container->setParameter('gesdinet_jwt_refresh_token.return_expiration_parameter_name', $config['return_expiration_parameter_name']);
 
         $refreshTokenClass = RefreshTokenEntity::class;
         $objectManager = 'doctrine.orm.entity_manager';

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -60,9 +60,21 @@ class AttachRefreshTokenOnSuccessListener
     protected array $cookieSettings;
 
     /**
+     * @var bool
+     */
+    protected $returnExpiration;
+
+    /**
+     * @var string
+     */
+    protected $returnExpirationParameterName;
+
+    /**
      * @param int    $ttl
      * @param string $tokenParameterName
      * @param bool   $singleUse
+     * @param bool   $returnExpiration
+     * @param string $returnExpirationParameterName
      */
     public function __construct(
         RefreshTokenManagerInterface $refreshTokenManager,
@@ -72,7 +84,9 @@ class AttachRefreshTokenOnSuccessListener
         $singleUse,
         RefreshTokenGeneratorInterface $refreshTokenGenerator,
         ExtractorInterface $extractor,
-        array $cookieSettings
+        array $cookieSettings,
+        $returnExpiration,
+        $returnExpirationParameterName
     ) {
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;
@@ -90,6 +104,8 @@ class AttachRefreshTokenOnSuccessListener
             'secure' => true,
             'remove_token_from_body' => true,
         ], $cookieSettings);
+        $this->returnExpiration = $returnExpiration;
+        $this->returnExpirationParameterName = $returnExpirationParameterName;
     }
 
     public function attachRefreshToken(AuthenticationSuccessEvent $event): void
@@ -129,6 +145,10 @@ class AttachRefreshTokenOnSuccessListener
             $this->refreshTokenManager->save($refreshToken);
             $refreshTokenString = $refreshToken->getRefreshToken();
             $data[$this->tokenParameterName] = $refreshTokenString;
+        }
+
+        if ($this->returnExpiration) {
+            $data[$this->returnExpirationParameterName] = time() + $this->ttl;
         }
 
         // Add a response cookie if enabled

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -67,8 +67,6 @@ class AttachRefreshTokenOnSuccessListener
      * @param int    $ttl
      * @param string $tokenParameterName
      * @param bool   $singleUse
-     * @param bool   $returnExpiration
-     * @param string $returnExpirationParameterName
      */
     public function __construct(
         RefreshTokenManagerInterface $refreshTokenManager,

--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -59,15 +59,9 @@ class AttachRefreshTokenOnSuccessListener
 
     protected array $cookieSettings;
 
-    /**
-     * @var bool
-     */
-    protected $returnExpiration;
+    protected bool $returnExpiration;
 
-    /**
-     * @var string
-     */
-    protected $returnExpirationParameterName;
+    protected string $returnExpirationParameterName;
 
     /**
      * @param int    $ttl
@@ -85,8 +79,8 @@ class AttachRefreshTokenOnSuccessListener
         RefreshTokenGeneratorInterface $refreshTokenGenerator,
         ExtractorInterface $extractor,
         array $cookieSettings,
-        $returnExpiration,
-        $returnExpirationParameterName
+        bool $returnExpiration = false,
+        string $returnExpirationParameterName = 'refresh_token_expiration'
     ) {
         $this->refreshTokenManager = $refreshTokenManager;
         $this->ttl = $ttl;

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ gesdinet_jwt_refresh_token:
 
 ### Return Expiration Timestamp
 
-If set to true, the expiration timestamp will be added to the response.
+If set to true, the expiration Unix timestamp will be added to the response.
 
 ```yaml
 gesdinet_jwt_refresh_token:

--- a/README.md
+++ b/README.md
@@ -220,6 +220,22 @@ gesdinet_jwt_refresh_token:
     token_parameter_name: refreshToken
 ```
 
+### Return Expiration Timestamp
+
+If set to true, the expiration timestamp will be added to the response.
+
+```yaml
+gesdinet_jwt_refresh_token:
+    return_expiration: true
+```
+
+The default parameter name is `refresh_token_expiration`. You can change the parameter name by adding this line to your config and changing it:
+
+```yaml
+gesdinet_jwt_refresh_token:
+    return_expiration_parameter_name: refresh_token_expiration
+```
+
 ### Set The User Provider
 
 #### Symfony 5.4+

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -54,6 +54,8 @@ return static function (ContainerConfigurator $container) {
             new Reference('gesdinet.jwtrefreshtoken.refresh_token_generator'),
             new Reference('gesdinet.jwtrefreshtoken.request.extractor.chain'),
             new Parameter('gesdinet_jwt_refresh_token.cookie'),
+            new Parameter('gesdinet_jwt_refresh_token.return_expiration'),
+            new Parameter('gesdinet_jwt_refresh_token.return_expiration_parameter_name'),
         ])
         ->tag('kernel.event_listener', [
             'event' => 'lexik_jwt_authentication.on_authentication_success',

--- a/Tests/Unit/EventListener/AttachRefreshTokenOnSuccessListenerTest.php
+++ b/Tests/Unit/EventListener/AttachRefreshTokenOnSuccessListenerTest.php
@@ -20,6 +20,8 @@ class AttachRefreshTokenOnSuccessListenerTest extends TestCase
 {
     const TTL = 2592000;
     const TOKEN_PARAMETER_NAME = 'refresh_token';
+    const RETURN_EXPIRATION = false;
+    const RETURN_EXPIRATION_PARAMETER_NAME = 'refresh_token_ttl';
 
     /**
      * @var RefreshTokenManagerInterface|MockObject
@@ -58,7 +60,9 @@ class AttachRefreshTokenOnSuccessListenerTest extends TestCase
             false,
             $this->refreshTokenGenerator,
             $this->extractor,
-            []
+            [],
+            self::RETURN_EXPIRATION,
+            self::RETURN_EXPIRATION_PARAMETER_NAME
         );
     }
 
@@ -154,7 +158,9 @@ class AttachRefreshTokenOnSuccessListenerTest extends TestCase
             false,
             $this->refreshTokenGenerator,
             $this->extractor,
-            ['enabled' => true]
+            ['enabled' => true],
+            self::RETURN_EXPIRATION,
+            self::RETURN_EXPIRATION_PARAMETER_NAME
         ))->attachRefreshToken($event);
     }
 


### PR DESCRIPTION
This adds a expiration timestamp to the response, if enabled. This feature is disabled by default.

> ### Return Expiration Timestamp
> 
> If set to true, the expiration timestamp will be added to the response.
> 
> ```yaml
> gesdinet_jwt_refresh_token:
>     return_expiration: true
> ```
> 
> The default parameter name is `refresh_token_expiration`. You can change the parameter name by adding this line to your config and changing it:
> 
> ```yaml
> gesdinet_jwt_refresh_token:
>     return_expiration_parameter_name: refresh_token_expiration
> ```