### PR TITLE
Improve the output from the console commands

### DIFF
--- a/Command/RevokeRefreshTokenCommand.php
+++ b/Command/RevokeRefreshTokenCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class RevokeRefreshTokenCommand extends Command
 {
@@ -39,20 +40,22 @@ class RevokeRefreshTokenCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
+
         /** @var string $refreshTokenParam */
         $refreshTokenParam = $input->getArgument('refresh_token');
 
         $refreshToken = $this->refreshTokenManager->get($refreshTokenParam);
 
         if (null === $refreshToken) {
-            $output->writeln(sprintf('<error>Not Found:</error> Refresh Token <comment>%s</comment> doesn\'t exist', $refreshTokenParam));
+            $io->error(sprintf('Refresh token "%s" does not exist', $refreshTokenParam));
 
             return 1;
         }
 
         $this->refreshTokenManager->delete($refreshToken);
 
-        $output->writeln(sprintf('Revoked <comment>%s</comment>', $refreshToken->getRefreshToken()));
+        $io->success(sprintf('Revoked refresh token "%s"', $refreshTokenParam));
 
         return 0;
     }

--- a/Tests/Functional/Command/ClearInvalidRefreshTokensCommandTest.php
+++ b/Tests/Functional/Command/ClearInvalidRefreshTokensCommandTest.php
@@ -32,7 +32,11 @@ final class ClearInvalidRefreshTokensCommandTest extends TestCase
         $commandTester->execute([]);
 
         $this->assertSame(0, $commandTester->getStatusCode());
-        $this->assertStringContainsString('Revoked refresh-token', $commandTester->getDisplay());
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('Revoked 1 invalid token(s)', $output, 'The output should include a summary of the number of invalidated tokens');
+        $this->assertStringContainsString('* refresh-token', $output, 'The output should list all invalidated tokens');
     }
 
     public function test_clears_tokens_with_timestamp(): void
@@ -56,6 +60,10 @@ final class ClearInvalidRefreshTokensCommandTest extends TestCase
         $commandTester->execute(['datetime' => '2021-01-01']);
 
         $this->assertSame(0, $commandTester->getStatusCode());
-        $this->assertStringContainsString('Revoked refresh-token', $commandTester->getDisplay());
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('Revoked 1 invalid token(s)', $output, 'The output should include a summary of the number of invalidated tokens');
+        $this->assertStringContainsString('* refresh-token', $output, 'The output should list all invalidated tokens');
     }
 }

--- a/Tests/Functional/Command/RevokeRefreshTokenCommandTest.php
+++ b/Tests/Functional/Command/RevokeRefreshTokenCommandTest.php
@@ -28,7 +28,7 @@ final class RevokeRefreshTokenCommandTest extends TestCase
         $commandTester->execute(['refresh_token' => $token]);
 
         $this->assertSame(1, $commandTester->getStatusCode());
-        $this->assertStringContainsString('Not Found:', $commandTester->getDisplay());
+        $this->assertStringContainsString('does not exist', $commandTester->getDisplay());
     }
 
     public function test_revokes_a_token(): void
@@ -37,9 +37,6 @@ final class RevokeRefreshTokenCommandTest extends TestCase
 
         /** @var MockObject|RefreshTokenInterface $refreshToken */
         $refreshToken = $this->createMock(RefreshTokenInterface::class);
-        $refreshToken->expects($this->once())
-            ->method('getRefreshToken')
-            ->willReturn($token);
 
         /** @var MockObject|RefreshTokenManagerInterface $refreshTokenManager */
         $refreshTokenManager = $this->createMock(RefreshTokenManagerInterface::class);
@@ -54,6 +51,6 @@ final class RevokeRefreshTokenCommandTest extends TestCase
         $commandTester->execute(['refresh_token' => $token]);
 
         $this->assertSame(0, $commandTester->getStatusCode());
-        $this->assertStringContainsString('Revoked refresh-token', $commandTester->getDisplay());
+        $this->assertStringContainsString('Revoked refresh token', $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
This just makes some minor adjustments to the CLI output which IMO improves the display a bit.

There is now an output when the `gesdinet:jwt:clear` command when it clears zero tokens, the clear command will also give a summary statement stating how many tokens were cleared (previously one would have to count each line), and the outputs are all styled with the `SymfonyStyle` class instead of manual formatting.

Clear command before:
<img width="1100" alt="Screen Shot 2022-04-10 at 1 34 21 PM" src="https://user-images.githubusercontent.com/368545/162634460-c3bec812-e83f-49e5-919c-60436622cb09.png">

Clear command after:
<img width="1059" alt="Screen Shot 2022-04-10 at 1 34 34 PM" src="https://user-images.githubusercontent.com/368545/162634464-668d961e-4413-4cf0-adfa-dbf9c4b08b29.png">