### PR TITLE
Make doctrine/persistence a required dependency and support 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   ],
   "require" : {
     "php": ">=7.4",
+    "doctrine/persistence": "^1.3.3|^2.0|3.0",
     "lexik/jwt-authentication-bundle": "^2.0",
     "symfony/config": "^4.4|^5.4|^6.0",
     "symfony/console": "^4.4|^5.4|^6.0",
@@ -31,7 +32,6 @@
   "require-dev": {
     "doctrine/cache": "^1.11|^2.0",
     "doctrine/mongodb-odm": "^2.0",
-    "doctrine/persistence": "^1.3.3|^2.0",
     "doctrine/orm": "^2.7",
     "matthiasnoback/symfony-config-test": "^4.2",
     "matthiasnoback/symfony-dependency-injection-test": "^4.2",
@@ -41,8 +41,7 @@
   },
   "conflict": {
     "doctrine/mongodb-odm": "<2.0",
-    "doctrine/orm": "<2.7",
-    "doctrine/persistence": "<1.3.3"
+    "doctrine/orm": "<2.7"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
The `doctrine/persistence` package is pretty much a required dependency of this bundle given the `RefreshTokenRepositoryInterface` extends from the `ObjectRepository` interface and the token manager requires an `ObjectManager` instance.  So unless you're trying to use this bundle without Doctrine at all (which, while I guess is possible, would probably be an extremely niche use case), this should pretty much always be installed.  Therefore, this PR adds it to the required dependency list and adds full support for the new 3.0 release.