### PR TITLE
Fix token expiration date

### DIFF
--- a/EventListener/AttachRefreshTokenOnSuccessListener.php
+++ b/EventListener/AttachRefreshTokenOnSuccessListener.php
@@ -131,16 +131,21 @@ class AttachRefreshTokenOnSuccessListener
         // Set or create the refreshTokenString
         if ($refreshTokenString) {
             $data[$this->tokenParameterName] = $refreshTokenString;
+
+            if ($this->returnExpiration) {
+                $refreshToken = $this->refreshTokenManager->get($refreshTokenString);
+                $data[$this->returnExpirationParameterName] = ($refreshToken) ? $refreshToken->getValid()->getTimestamp() : 0;
+            }
         } else {
             $refreshToken = $this->refreshTokenGenerator->createForUserWithTtl($user, $this->ttl);
 
             $this->refreshTokenManager->save($refreshToken);
             $refreshTokenString = $refreshToken->getRefreshToken();
             $data[$this->tokenParameterName] = $refreshTokenString;
-        }
 
-        if ($this->returnExpiration) {
-            $data[$this->returnExpirationParameterName] = time() + $this->ttl;
+            if ($this->returnExpiration) {
+                $data[$this->returnExpirationParameterName] = $refreshToken->getValid()->getTimestamp();
+            }
         }
 
         // Add a response cookie if enabled


### PR DESCRIPTION
Hello maintainers,

Instead of using `time() + $this->ttl` my suggestion is to use the `getValid()` method of the token. If you request a new token through `/api/token/refresh`, you get the latest unix time while the token may expire another timestamp. This fix uses the getValid method and turns it into an timestamp.

As always I am open to suggestions, critical feedback leading to improvements on this PR or comments 👍