### PR TITLE
Fix deprecations on Symfony 6.1

### DIFF
--- a/Command/ClearInvalidRefreshTokensCommand.php
+++ b/Command/ClearInvalidRefreshTokensCommand.php
@@ -13,14 +13,19 @@ namespace Gesdinet\JWTRefreshTokenBundle\Command;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'gesdinet:jwt:clear', description: 'Clear invalid refresh tokens.')]
 class ClearInvalidRefreshTokensCommand extends Command
 {
+    /**
+     * @deprecated
+     */
     protected static $defaultName = 'gesdinet:jwt:clear';
 
     private RefreshTokenManagerInterface $refreshTokenManager;

--- a/Command/RevokeRefreshTokenCommand.php
+++ b/Command/RevokeRefreshTokenCommand.php
@@ -12,14 +12,19 @@
 namespace Gesdinet\JWTRefreshTokenBundle\Command;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'gesdinet:jwt:revoke', description: 'Revoke a refresh token')]
 class RevokeRefreshTokenCommand extends Command
 {
+    /**
+     * @deprecated
+     */
     protected static $defaultName = 'gesdinet:jwt:revoke';
 
     private RefreshTokenManagerInterface $refreshTokenManager;


### PR DESCRIPTION
Fix deprecation notice:

> Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute instead.
