### PR TITLE
[1.x] Adjust CI setup to get functional MongoDB install again

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     continue-on-error: ${{ matrix.can-fail }}
     strategy:
       fail-fast: false
@@ -48,7 +48,7 @@ jobs:
         id: setup-mongodb
         uses: mongodb-labs/drivers-evergreen-tools@master
         with:
-          version: '4.4'
+          version: '5.0'
           topology: server
 
       - name: Remove Guard


### PR DESCRIPTION
Extracted from #347

With GitHub updating the `ubuntu-latest` alias to 22.04, the `mongodb-labs/drivers-evergreen-tools` action can't set up a MongoDB server correctly anymore.  It doesn't look to support the latest Ubuntu LTS, so this downgrades the Ubuntu version.

The MongoDB server version is upgraded as well.