### PR TITLE
[1.x] Fix PHP 8.2 compat issue in uses of `DateTime::modify()`

### DIFF
--- a/Model/AbstractRefreshToken.php
+++ b/Model/AbstractRefreshToken.php
@@ -41,7 +41,13 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     public static function createForUserWithTtl(string $refreshToken, UserInterface $user, int $ttl): RefreshTokenInterface
     {
         $valid = new \DateTime();
-        $valid->modify('+'.$ttl.' seconds');
+
+        // Explicitly check for a negative number based on a behavior change in PHP 8.2, see https://github.com/php/php-src/issues/9950
+        if ($ttl > 0) {
+            $valid->modify('+'.$ttl.' seconds');
+        } elseif ($ttl < 0) {
+            $valid->modify($ttl.' seconds');
+        }
 
         $model = new static();
         $model->setRefreshToken($refreshToken);

--- a/Security/Http/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Http/Authenticator/RefreshTokenAuthenticator.php
@@ -116,7 +116,14 @@ class RefreshTokenAuthenticator extends AbstractAuthenticator implements Authent
 
         if ($this->options['ttl_update']) {
             $expirationDate = new \DateTime();
-            $expirationDate->modify(sprintf('+%d seconds', $this->options['ttl']));
+
+            // Explicitly check for a negative number based on a behavior change in PHP 8.2, see https://github.com/php/php-src/issues/9950
+            if ($this->options['ttl'] > 0) {
+                $expirationDate->modify(sprintf('+%d seconds', $this->options['ttl']));
+            } elseif ($this->options['ttl'] < 0) {
+                $expirationDate->modify(sprintf('%d seconds', $this->options['ttl']));
+            }
+
             $refreshToken->setValid($expirationDate);
 
             $this->refreshTokenManager->save($refreshToken);


### PR DESCRIPTION
As noted in https://github.com/php/php-src/issues/9950 there is a behavioral change in PHP 8.2 if you make a call like `$dateTime->modify('+-300 seconds')` as a result of another bug fix in the date/time handling libraries.  As the bundle does not enforce TTLs to be a positive number (and the functional tests abuse this a bit), this is a practical fix to ensure anything passing a negative TTL value doesn't catastrophically break.