### PR TITLE
Add firewall example for multiple user providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ security:
             jwt: ~
             refresh_jwt:
                 check_path: /api/token/refresh # or, you may use the `api_refresh_token` route name
+                # or if you have more than one user provider
+                # provider: user_provider_name
     # ...
 
     access_control:
@@ -200,6 +202,8 @@ security:
             pattern:  ^/api/token/refresh
             stateless: true
             anonymous: true
+            # or if you have more than one user provider
+            #provider: user_provider_name
     # ...
 
     access_control:


### PR DESCRIPTION
Creating new PR after inadvertently closing #299

Regarding #255 and the need to specify the `provider` key if used within an app with more than one user provider, here is a minimal update to the readme with commented-out examples of how to specify the required user provider.