### PR TITLE
Remove deprecated since Symfony 6.2

### DIFF
--- a/Request/Extractor/RequestBodyExtractor.php
+++ b/Request/Extractor/RequestBodyExtractor.php
@@ -17,7 +17,9 @@ final class RequestBodyExtractor implements ExtractorInterface
 {
     public function getRefreshToken(Request $request, string $parameter): ?string
     {
-        if (null === $request->getContentType() || false === strpos($request->getContentType(), 'json')) {
+        $contentType = method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType();
+        
+        if (null === $contentType || false === strpos($contentType, 'json')) {
             return null;
         }
 

--- a/Request/Extractor/RequestBodyExtractor.php
+++ b/Request/Extractor/RequestBodyExtractor.php
@@ -18,7 +18,7 @@ final class RequestBodyExtractor implements ExtractorInterface
     public function getRefreshToken(Request $request, string $parameter): ?string
     {
         $contentType = method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType();
-        
+
         if (null === $contentType || false === strpos($contentType, 'json')) {
             return null;
         }


### PR DESCRIPTION
> User Deprecated: Since symfony/http-foundation 6.2: The "Symfony\Component\HttpFoundation\Request::getContentType()" method is deprecated, use "getContentTypeFormat()" instead.

https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/HttpFoundation/Request.php#L1313-L1323