### PR TITLE
Update CI and fix tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        symfony: ['4.4.*', '5.4.*', '6.0.*']
+        php: ['7.4', '8.0', '8.1', '8.2']
+        symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*', '6.2.*', '6.3.*']
         composer-flags: ['--prefer-stable']
         can-fail: [false]
         extensions: ['curl, iconv, mbstring, mongodb, pdo, pdo_sqlite, sqlite, zip']
@@ -23,15 +23,27 @@ jobs:
         exclude:
           - php: '7.4'
             symfony: '6.0.*'
+          - php: '7.4'
+            symfony: '6.1.*'
+          - php: '7.4'
+            symfony: '6.2.*'
+          - php: '7.4'
+            symfony: '6.3.*'
+          - php: '8.0'
+            symfony: '6.1.*'
+          - php: '8.0'
+            symfony: '6.2.*'
+          - php: '8.0'
+            symfony: '6.3.*'
 
     name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-symfony-${{ matrix.symfony }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}-flags-${{ matrix.composer-flags }}
@@ -52,7 +64,7 @@ jobs:
           topology: server
 
       - name: Remove Guard
-        if: matrix.symfony == '6.0.*'
+        if: contains(fromJSON('["6.0.*", "6.1.*", "6.2.*", "6.3.*"]'), matrix.symfony)
         run: composer remove --dev --no-update symfony/security-guard
 
       - name: Install dependencies

--- a/Model/AbstractRefreshToken.php
+++ b/Model/AbstractRefreshToken.php
@@ -41,7 +41,13 @@ abstract class AbstractRefreshToken implements RefreshTokenInterface
     public static function createForUserWithTtl(string $refreshToken, UserInterface $user, int $ttl): RefreshTokenInterface
     {
         $valid = new \DateTime();
-        $valid->modify('+'.$ttl.' seconds');
+
+        // Explicitly check for a negative number based on a behavior change in PHP 8.2, see https://github.com/php/php-src/issues/9950
+        if ($ttl > 0) {
+            $valid->modify('+'.$ttl.' seconds');
+        } elseif ($ttl < 0) {
+            $valid->modify($ttl.' seconds');
+        }
 
         $model = new static();
         $model->setRefreshToken($refreshToken);

--- a/Security/Http/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Http/Authenticator/RefreshTokenAuthenticator.php
@@ -116,7 +116,14 @@ class RefreshTokenAuthenticator extends AbstractAuthenticator implements Authent
 
         if ($this->options['ttl_update']) {
             $expirationDate = new \DateTime();
-            $expirationDate->modify(sprintf('+%d seconds', $this->options['ttl']));
+
+            // Explicitly check for a negative number based on a behavior change in PHP 8.2, see https://github.com/php/php-src/issues/9950
+            if ($this->options['ttl'] > 0) {
+                $expirationDate->modify(sprintf('+%d seconds', $this->options['ttl']));
+            } elseif ($this->options['ttl'] < 0) {
+                $expirationDate->modify(sprintf('%d seconds', $this->options['ttl']));
+            }
+
             $refreshToken->setValid($expirationDate);
 
             $this->refreshTokenManager->save($refreshToken);

--- a/Tests/Unit/Request/Extractor/RequestBodyExtractorTest.php
+++ b/Tests/Unit/Request/Extractor/RequestBodyExtractorTest.php
@@ -59,7 +59,7 @@ class RequestBodyExtractorTest extends TestCase
 
         $request
             ->expects($this->atLeastOnce())
-            ->method('getContentType')
+            ->method(method_exists(Request::class, 'getContentTypeFormat') ? 'getContentTypeFormat' : 'getContentType')
             ->willReturn($contentType);
 
         if (is_array($jsonBodyData)) {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-require dirname(__DIR__).'/vendor/autoload.php';
-
-\Doctrine\Common\Annotations\AnnotationRegistry::registerLoader('class_exists');

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "symfony/security-http": "^4.4|^5.4|^6.0"
   },
   "require-dev": {
+    "doctrine/annotations": "^1.13|^2.0",
     "doctrine/cache": "^1.11|^2.0",
     "doctrine/mongodb-odm": "^2.2",
     "doctrine/orm": "^2.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         colors="true"
-        bootstrap="Tests/bootstrap.php"
+        bootstrap="vendor/autoload.php"
         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
 >
     <testsuites>
@@ -18,7 +18,6 @@
         <exclude>
             <directory>./Resources</directory>
             <directory>./Tests</directory>
-            <directory>./spec</directory>
             <directory>./vendor</directory>
         </exclude>
     </coverage>


### PR DESCRIPTION
This will fix CI by:

- Requiring a version of `doctrine/annotations` for development that supports autoloading, removing the need to register a loader in the PHPUnit bootstrap
- Fix the broken tests in `Gesdinet\JWTRefreshTokenBundle\Tests\Unit\Request\Extractor\RequestBodyExtractorTest` by making it aware of the compat changes in #355
- Update the test matrix to test on PHP 8.2 and Symfony 6.1-6.3 (the above PR would've failed if there were a build on the newer Symfony versions, but it's just a test fail so not the worst issue in the world)
- Includes #349 which is needed to fix a PHP 8.2 compatibility issue