### PR TITLE
Fix SF 7 compat

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2']
-        symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*', '6.2.*', '6.3.*']
+        symfony: ['4.4.*', '5.4.*', '6.0.*', '6.1.*', '6.2.*', '6.3.*', '6.4.*', '7.0.*']
         composer-flags: ['--prefer-stable']
         can-fail: [false]
         extensions: ['curl, iconv, mbstring, mongodb, pdo, pdo_sqlite, sqlite, zip']
@@ -29,18 +29,28 @@ jobs:
             symfony: '6.2.*'
           - php: '7.4'
             symfony: '6.3.*'
+          - php: '7.4'
+            symfony: '6.4.*'
+          - php: '7.4'
+            symfony: '7.0.*'
           - php: '8.0'
             symfony: '6.1.*'
           - php: '8.0'
             symfony: '6.2.*'
           - php: '8.0'
             symfony: '6.3.*'
+          - php: '8.0'
+            symfony: '6.4.*'
+          - php: '8.0'
+            symfony: '7.0.*'
+          - php: '8.1'
+            symfony: '7.0.*'
 
     name: "PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}${{ matrix.composer-flags != '' && format(' - Composer {0}', matrix.composer-flags) || '' }}"
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -63,8 +73,8 @@ jobs:
           version: '5.0'
           topology: server
 
-      - name: Remove Guard
-        if: contains(fromJSON('["6.0.*", "6.1.*", "6.2.*", "6.3.*"]'), matrix.symfony)
+      - name: Remove Guard (Symfony >=6.0)
+        if: contains(fromJSON('["6.0.*", "6.1.*", "6.2.*", "6.3.*", "6.4.*", "7.0.*"]'), matrix.symfony)
         run: composer remove --dev --no-update symfony/security-guard
 
       - name: Install dependencies

--- a/Security/Exception/InvalidTokenException.php
+++ b/Security/Exception/InvalidTokenException.php
@@ -15,10 +15,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class InvalidTokenException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid JWT Refresh Token';
     }

--- a/Security/Exception/MissingTokenException.php
+++ b/Security/Exception/MissingTokenException.php
@@ -15,10 +15,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class MissingTokenException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Missing JWT Refresh Token';
     }

--- a/Security/Exception/TokenNotFoundException.php
+++ b/Security/Exception/TokenNotFoundException.php
@@ -15,10 +15,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class TokenNotFoundException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'JWT Refresh Token Not Found';
     }

--- a/Security/Provider/RefreshTokenProvider.php
+++ b/Security/Provider/RefreshTokenProvider.php
@@ -21,10 +21,56 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 
 trigger_deprecation('gesdinet/jwt-refresh-token-bundle', '1.0', 'The "%s" class is deprecated, configure the user provider for the `refresh_jwt` authenticator instead.', RefreshTokenProvider::class);
 
+if ((new \ReflectionClass(UserProviderInterface::class))->getMethod('supportsClass')->hasReturnType()) {
+    /**
+     * Compatibility layer for Symfony 7.0 and later, where {@see UserProviderInterface::supportsClass()} has a return type.
+     *
+     * @internal
+     */
+    abstract class CompatRefreshTokenProvider implements UserProviderInterface
+    {
+        /**
+         * @param class-string<UserInterface> $class
+         */
+        public function supportsClass(string $class): bool
+        {
+            return $this->doSupportsClass($class);
+        }
+
+        /**
+         * @param class-string<UserInterface> $class
+         */
+        abstract protected function doSupportsClass(string $class): bool;
+    }
+} else {
+    /**
+     * Compatibility layer for Symfony 6.4 and earlier, where {@see UserProviderInterface::supportsClass()} does not have a return type.
+     *
+     * @internal
+     */
+    abstract class CompatRefreshTokenProvider implements UserProviderInterface
+    {
+        /**
+         * @param class-string<UserInterface> $class
+         *
+         * @return bool
+         */
+        public function supportsClass($class)
+        {
+            return $this->doSupportsClass($class);
+        }
+
+        /**
+         * @param class-string<UserInterface> $class
+         */
+        abstract protected function doSupportsClass(string $class): bool;
+    }
+}
+
 /**
  * @deprecated configure the user provider for the `refresh_jwt` authenticator instead
  */
-class RefreshTokenProvider implements UserProviderInterface
+class RefreshTokenProvider extends CompatRefreshTokenProvider
 {
     /**
      * @var RefreshTokenManagerInterface
@@ -102,10 +148,7 @@ class RefreshTokenProvider implements UserProviderInterface
         );
     }
 
-    /**
-     * @return UserInterface
-     */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         if (null !== $this->customUserProvider) {
             return $this->customUserProvider->refreshUser($user);
@@ -116,10 +159,8 @@ class RefreshTokenProvider implements UserProviderInterface
 
     /**
      * @param class-string<UserInterface> $class
-     *
-     * @return bool
      */
-    public function supportsClass($class)
+    protected function doSupportsClass(string $class): bool
     {
         if (null !== $this->customUserProvider) {
             return $this->customUserProvider->supportsClass($class);

--- a/Tests/Unit/EventListener/AttachRefreshTokenOnSuccessListenerTest.php
+++ b/Tests/Unit/EventListener/AttachRefreshTokenOnSuccessListenerTest.php
@@ -298,6 +298,10 @@ class AttachRefreshTokenOnSuccessListenerTest extends TestCase
 
     public function testDoesNothingWhenThereIsNotAUser()
     {
+        if ((new \ReflectionClass(AuthenticationSuccessEvent::class))->getMethod('getUser')->hasReturnType()) {
+            $this->markTestSkipped(sprintf('%s::getUser() has a non-nullable return type in LexikJWTAuthenticationBundle 3.x', AuthenticationSuccessEvent::class));
+        }
+
         /** @var AuthenticationSuccessEvent|MockObject $event */
         $event = $this->createMock(AuthenticationSuccessEvent::class);
 

--- a/Tests/Unit/Request/Extractor/RequestCookieExtractorTest.php
+++ b/Tests/Unit/Request/Extractor/RequestCookieExtractorTest.php
@@ -6,6 +6,7 @@ use Gesdinet\JWTRefreshTokenBundle\Request\Extractor\ExtractorInterface;
 use Gesdinet\JWTRefreshTokenBundle\Request\Extractor\RequestCookieExtractor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -29,13 +30,9 @@ class RequestCookieExtractorTest extends TestCase
     {
         $token = 'my-refresh-token';
 
-        /** @var ParameterBag|MockObject $cookieBag */
-        $cookieBag = $this->createMock(ParameterBag::class);
-        $cookieBag
-            ->expects($this->once())
-            ->method('get')
-            ->with(self::PARAMETER_NAME)
-            ->willReturn($token);
+        /** @var ParameterBag|InputBag $cookieBag */
+        $cookieBag = class_exists(InputBag::class) ? new InputBag() : new ParameterBag();
+        $cookieBag->set(self::PARAMETER_NAME, $token);
 
         /** @var Request|MockObject $request */
         $request = $this->createMock(Request::class);

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,11 @@
     "doctrine/cache": "^1.11|^2.0",
     "doctrine/mongodb-odm": "^2.2",
     "doctrine/orm": "^2.7",
-    "matthiasnoback/symfony-config-test": "^4.2",
-    "matthiasnoback/symfony-dependency-injection-test": "^4.2",
+    "matthiasnoback/symfony-config-test": "^4.2|^5.0",
+    "matthiasnoback/symfony-dependency-injection-test": "^4.2|^5.0",
     "phpunit/phpunit": "^9.5",
     "symfony/cache": "^4.4|^5.4|^6.0|^7.0",
-    "symfony/security-guard": "^4.4|^5.4|^6.0|^7.0"
+    "symfony/security-guard": "^4.4|^5.4"
   },
   "conflict": {
     "doctrine/mongodb-odm": "<2.2",


### PR DESCRIPTION
The [Symfony 7 compat PR](https://github.com/markitosgv/JWTRefreshTokenBundle/pull/365) was merged and released too quickly, given that:

- ~`lexik/jwt-authentication-bundle` itself [has a pending PR](https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1165) for Symfony 7 support~ Merged
- The original PR added  `symfony/security-guard` versions that do not exist to the Composer manifest
- The original PR didn't add CI coverage for Symfony 7 (or 6.4), so the passing CI is a false positive since that combination is untested

~This PR is a draft PR until the `lexik/jwt-authentication-bundle` PR is merged, as that will block the Symfony 7 build from running until it's merged/released.~ Issues fixed and ready for review/merge.