### PR TITLE
fix: return type issue for php8.1

### DIFF
--- a/Security/Exception/InvalidTokenException.php
+++ b/Security/Exception/InvalidTokenException.php
@@ -18,7 +18,7 @@ class InvalidTokenException extends AuthenticationException
     /**
      * @return string
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid JWT Refresh Token';
     }

--- a/Security/Exception/InvalidTokenException.php
+++ b/Security/Exception/InvalidTokenException.php
@@ -15,9 +15,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class InvalidTokenException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
     public function getMessageKey(): string
     {
         return 'Invalid JWT Refresh Token';

--- a/Security/Exception/MissingTokenException.php
+++ b/Security/Exception/MissingTokenException.php
@@ -18,7 +18,7 @@ class MissingTokenException extends AuthenticationException
     /**
      * @return string
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Missing JWT Refresh Token';
     }

--- a/Security/Exception/MissingTokenException.php
+++ b/Security/Exception/MissingTokenException.php
@@ -15,9 +15,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class MissingTokenException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
     public function getMessageKey(): string
     {
         return 'Missing JWT Refresh Token';

--- a/Security/Exception/TokenNotFoundException.php
+++ b/Security/Exception/TokenNotFoundException.php
@@ -18,7 +18,7 @@ class TokenNotFoundException extends AuthenticationException
     /**
      * @return string
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'JWT Refresh Token Not Found';
     }

--- a/Security/Exception/TokenNotFoundException.php
+++ b/Security/Exception/TokenNotFoundException.php
@@ -15,9 +15,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class TokenNotFoundException extends AuthenticationException
 {
-    /**
-     * @return string
-     */
     public function getMessageKey(): string
     {
         return 'JWT Refresh Token Not Found';


### PR DESCRIPTION
Without setting the return type in the exceptions, I get the error already logged here:

#369 

Hope this helps, it is a really simple fix.