### PR TITLE
fix: add parameter `partitioned` to clear a cookie on logout

### DIFF
--- a/EventListener/LogoutEventListener.php
+++ b/EventListener/LogoutEventListener.php
@@ -103,7 +103,8 @@ class LogoutEventListener
                 $this->cookieSettings['domain'],
                 $this->cookieSettings['secure'],
                 $this->cookieSettings['http_only'],
-                $this->cookieSettings['same_site']
+                $this->cookieSettings['same_site'],
+                $this->cookieSettings['partitioned']
             );
         }
     }


### PR DESCRIPTION
Related PR:
- https://github.com/markitosgv/JWTRefreshTokenBundle/pull/368
- https://github.com/symfony/symfony/pull/53703

This PR is the continuation of https://github.com/markitosgv/JWTRefreshTokenBundle/pull/368 with adding the parameter `partitioned` to clear a cookie on logout. It will be possible after the merge of https://github.com/symfony/symfony/pull/53703 on the Symfony project.

It is useful because a cookie created with the parameter `partitioned` can be deleted only if we define it on clear too.