### PR TITLE
Update the test environment to use attributes on PHP 8 and allow testing with ORM 3.0

### DIFF
--- a/Tests/Functional/Fixtures/Document/RefreshToken.php
+++ b/Tests/Functional/Fixtures/Document/RefreshToken.php
@@ -8,6 +8,7 @@ use Gesdinet\JWTRefreshTokenBundle\Document\RefreshToken as BaseRefreshToken;
 /**
  * @ODM\Document
  */
+#[ODM\Document]
 class RefreshToken extends BaseRefreshToken
 {
 }

--- a/Tests/Functional/Fixtures/Document/User.php
+++ b/Tests/Functional/Fixtures/Document/User.php
@@ -8,21 +8,25 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * @ODM\Document
  */
+#[ODM\Document]
 class User implements UserInterface
 {
     /**
      * @ODM\Id
      */
+    #[ODM\Id]
     private ?string $id = null;
 
     /**
      * @ODM\Field
      */
+    #[ODM\Field]
     private string $email;
 
     /**
      * @ODM\Field(nullable=true)
      */
+    #[ODM\Field(nullable: true)]
     private ?string $password;
 
     public function __construct(string $email, ?string $password = null)

--- a/Tests/Functional/Fixtures/Entity/RefreshToken.php
+++ b/Tests/Functional/Fixtures/Entity/RefreshToken.php
@@ -8,6 +8,7 @@ use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
 /**
  * @ORM\Entity()
  */
+#[ORM\Entity]
 class RefreshToken extends BaseRefreshToken
 {
 }

--- a/Tests/Functional/Fixtures/Entity/User.php
+++ b/Tests/Functional/Fixtures/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional\Fixtures\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -10,6 +11,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *
  * @ORM\Table()
  */
+#[ORM\Entity]
+#[ORM\Table]
 class User implements UserInterface
 {
     /**
@@ -19,16 +22,21 @@ class User implements UserInterface
      *
      * @ORM\GeneratedValue(strategy="AUTO")
      */
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     private ?int $id = null;
 
     /**
      * @ORM\Column(type="string")
      */
+    #[ORM\Column(type: Types::STRING)]
     private string $email;
 
     /**
      * @ORM\Column(type="string", nullable=true)
      */
+    #[ORM\Column(type: Types::STRING, nullable: true)]
     private ?string $password;
 
     public function __construct(string $email, ?string $password = null)

--- a/Tests/Functional/ODMTestCase.php
+++ b/Tests/Functional/ODMTestCase.php
@@ -2,9 +2,13 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Tests\Functional;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AttributeDriver;
 use Doctrine\ODM\MongoDB\Mapping\Driver\SimplifiedXmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use MongoDB\Client;
@@ -39,18 +43,25 @@ abstract class ODMTestCase extends TestCase
 
         $driverChain = new MappingDriverChain();
 
-        $annotationDriver = $config->newDefaultAnnotationDriver([__DIR__.'/Fixtures/Document']);
-
-        $xmlDriver = new SimplifiedXmlDriver(
-            [(\dirname(__DIR__, 2).'/Resources/config/doctrine') => 'Gesdinet\\JWTRefreshTokenBundle\\Document'],
-            '.mongodb.xml'
-        );
+        if (\PHP_VERSION_ID >= 80000 && class_exists(AttributeDriver::class)) {
+            $driverChain->addDriver(
+                new AttributeDriver([__DIR__.'/Fixtures/Document']),
+                'Gesdinet\\JWTRefreshTokenBundle\\Tests\\Functional\\Fixtures\\Document'
+            );
+        } elseif (class_exists(AnnotationDriver::class) && interface_exists(Reader::class)) {
+            $driverChain->addDriver(
+                new AnnotationDriver(new AnnotationReader(), [__DIR__.'/Fixtures/Document']),
+                'Gesdinet\\JWTRefreshTokenBundle\\Tests\\Functional\\Fixtures\\Document'
+            );
+        }
 
         $driverChain->addDriver(
-            $annotationDriver,
-            'Gesdinet\\JWTRefreshTokenBundle\\Tests\\Functional\\Fixtures\\Document'
+            new SimplifiedXmlDriver(
+                [(\dirname(__DIR__, 2).'/Resources/config/doctrine') => 'Gesdinet\\JWTRefreshTokenBundle\\Document'],
+                '.mongodb.xml'
+            ),
+            'Gesdinet\\JWTRefreshTokenBundle\\Document'
         );
-        $driverChain->addDriver($xmlDriver, 'Gesdinet\\JWTRefreshTokenBundle\\Document');
 
         $config->setMetadataDriverImpl($driverChain);
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "doctrine/annotations": "^1.13|^2.0",
     "doctrine/cache": "^1.11|^2.0",
     "doctrine/mongodb-odm": "^2.2",
-    "doctrine/orm": "^2.7",
+    "doctrine/orm": "^2.7|^3.0",
     "matthiasnoback/symfony-config-test": "^4.2|^5.0",
     "matthiasnoback/symfony-dependency-injection-test": "^4.2|^5.0",
     "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
ORM 3.0 was released, which is the main motivation for this PR.  The test environment will now support being run with the new major version installed.

Additionally, for both the MongoDB ODM and ORM, the test environment will now use an attribute driver when run on PHP 8 and a version of each object manager that supports attributes, necessary for ORM 3.0 as annotation support is fully removed and will eventually be deprecated in the MongoDB ODM.