### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
+++ b/DependencyInjection/GesdinetJWTRefreshTokenExtension.php
@@ -18,7 +18,7 @@ use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as RefreshTokenEntity;
 use Gesdinet\JWTRefreshTokenBundle\Request\Extractor\ExtractorInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 class GesdinetJWTRefreshTokenExtension extends Extension


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component. As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1. As this bundle does not rely on the extra feature, it can use the base class from DI directly.

Related to https://github.com/markitosgv/JWTRefreshTokenBundle/issues/386