### PR TITLE
Fix Deprecation Notice in RefreshTokenAuthenticator::start Method

### DIFF
--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -146,7 +146,7 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
     /**
      * @return Response
      */
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, ?AuthenticationException $authException = null)
     {
         $data = [
             // you might translate this message

--- a/Security/Http/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Http/Authenticator/RefreshTokenAuthenticator.php
@@ -178,7 +178,7 @@ class RefreshTokenAuthenticator extends AbstractAuthenticator implements Authent
         return $this->failureHandler->onAuthenticationFailure($request, $exception);
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         $event = new RefreshTokenNotFoundEvent(
             new MissingTokenException('JWT Refresh Token not found', 0, $authException),


### PR DESCRIPTION
# Fix Deprecation Notice in RefreshTokenAuthenticator::start Method

### Summary
This pull request addresses a deprecation notice in the `GesdinetJWTRefreshTokenBundle` caused by the `start` method in the `RefreshTokenAuthenticator` class. The `$authException` parameter was implicitly nullable, which is deprecated in PHP 8.1+.

### Changes Made
- Updated the `start` method in `RefreshTokenAuthenticator` to explicitly declare the `$authException` parameter as nullable.

### Environment
- **PHP Version:** 8.1
- **Symfony Version:** 7.2
- **GesdinetJWTRefreshTokenBundle Version:** 1.4.0

### Additional Context
This change ensures compatibility with PHP 8.1+ and eliminates the deprecation notice in development and test environments.