### PR TITLE
Fix deprecation notice in RefreshTokenAuthenticator::start method

### DIFF
--- a/Security/Authenticator/RefreshTokenAuthenticator.php
+++ b/Security/Authenticator/RefreshTokenAuthenticator.php
@@ -146,7 +146,7 @@ class RefreshTokenAuthenticator extends AbstractGuardAuthenticator
     /**
      * @return Response
      */
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, ?AuthenticationException $authException = null)
     {
         $data = [
             // you might translate this message


### PR DESCRIPTION
Explicitly marked  parameter as nullable in the start method of the RefreshTokenAuthenticator class to comply with PHP 8.1+ standards.