### PR TITLE
Adjust setup for the ORMTestCase to avoid some deprecations with ORM 3.4

### DIFF
--- a/tests/Functional/ORMTestCase.php
+++ b/tests/Functional/ORMTestCase.php
@@ -21,8 +21,15 @@ abstract class ORMTestCase extends TestCase
         $config->setMetadataCache(new ArrayAdapter());
         $config->setQueryCache(new ArrayAdapter());
         $config->setResultCache(new ArrayAdapter());
-        $config->setProxyDir(sys_get_temp_dir().'/JWTRefreshTokenBundle/_files');
-        $config->setProxyNamespace(__NAMESPACE__.'\Proxies');
+
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'enableNativeLazyObjects')) {
+            $config->enableNativeLazyObjects(true);
+        } else {
+            $config->setLazyGhostObjectEnabled(true);
+            $config->setAutoGenerateProxyClasses(true);
+            $config->setProxyDir(sys_get_temp_dir().'/JWTRefreshTokenBundle/_files');
+            $config->setProxyNamespace(__NAMESPACE__.'\Proxies');
+        }
 
         $driverChain = new MappingDriverChain();
 


### PR DESCRIPTION
This should avoid the ORM functional tests using deprecated code paths on PHP 8.4 with ORM 3.4 and later.